### PR TITLE
doc: add information about pygit2 requirements

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -51,6 +51,13 @@ Requirements and Installation
 `moulin` requires Python 3.6+ to run. You might need :code:`pip` or
 :code:`pip3` tool to install it.
 
+Also `moulin` requires :code:`pygit2`. If it is not installed on your
+system, :code:`pip` will try to install it from repository. It may
+fail in case if you are missing :code:`libgit2` development files or
+if installed :code:`libgit2` is too old. So, it is better to install
+:code:`pygit2` globally. For example, on Ubuntu 18.04 you need to
+install :code:`python3-pygit2` package.
+
 `moulin` source code is stored at `GitHub
 <https://github.com/xen-troops/moulin>`_.
 


### PR DESCRIPTION
Moulin now have pygit2 in dependencies list. But it appears that in
some cases (like when using Ubuntu 18.04) pip/pip3 can't install
pygit2 from own repository because pygit2 depends on exact version of
libgit2. Which is provided by distro.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>