### PR TITLE
doc: Add description for debian pip bug

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -68,3 +68,15 @@ storage using ::
 
 command. Make sure that your :code:`PATH` environment variable
 includes :code:`/home/${USER}/.local/bin`.
+
+You can encounter problem with `pygit2` installation on some Ubuntu or
+Debian distribution due to this
+`bug<https://github.com/pypa/pip/issues/4222>`_. In this case you will
+need to use the following command ::
+
+  PIP_IGNORE_INSTALLED=0 pip3 install --user git+https://github.com/xen-troops/moulin
+
+as a workaround.
+
+Alternatively, you can clone the mentioned git repository and invoke
+:code:`moulin.py` directly.


### PR DESCRIPTION
There is a bug that originates from Debian, but which we encountered
in Ubuntu. It prevents installation via pip, due to combination of
different issues: implicit "--ignore-installed" use and very old
libgit2 version.

This patch provides documentation on how to work around this bug.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>