### PR TITLE
build_generator: make dyndep target depend on sources

### DIFF
--- a/moulin/build_generator.py
+++ b/moulin/build_generator.py
@@ -68,6 +68,7 @@ def generate_build(conf: MoulinConfiguration,
 
         generator.build(f".moulin_{comp_name}_dyndep",
                         "fetcherdep",
+                        inputs=source_stamps,
                         variables=dict(component=comp_name))
     rouge.gen_build(generator, rouge.get_available_images(conf.get_root_node()))
 


### PR DESCRIPTION
To generate list of dependencies from fetched sources, we need
to fetch sources first.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>