### PR TITLE
Switch to "deps" dependency tracking mechanism

### DIFF
--- a/moulin/builders/android.py
+++ b/moulin/builders/android.py
@@ -6,7 +6,6 @@ Android open source project (AOSP) builder module
 
 import os.path
 from typing import List
-from moulin.utils import construct_fetcher_dep_cmd
 from moulin.yaml_wrapper import YamlValue
 from moulin import ninja_syntax
 
@@ -24,7 +23,6 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     Generate yocto build rules for ninja
     """
     cmd = " && ".join([
-        construct_fetcher_dep_cmd(),
         "export $env",
         "cd $build_dir",
         "source build/envsetup.sh",
@@ -35,8 +33,6 @@ def gen_build_rules(generator: ninja_syntax.Writer):
                    command=f'bash -c "{cmd}"',
                    description="Invoke Android build system",
                    pool="console",
-                   deps="gcc",
-                   depfile=".moulin_$name.d",
                    restat=True)
     generator.newline()
 

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -32,7 +32,8 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     ])
     generator.rule("yocto_init_env",
                    command=f'bash -c "{cmd}"',
-                   description="Initialize Yocto build environment")
+                   description="Initialize Yocto build environment",
+                   restat=True)
     generator.newline()
 
     # Add bitbake layers by calling bitbake-layers script

--- a/moulin/make_syntax.py
+++ b/moulin/make_syntax.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 EPAM Systems
+"""
+Very minimal python module for generating Makefiles.
+Loosely based on Ninja generator.
+"""
+
+import textwrap
+from typing import List, Union, IO
+from .ninja_syntax import as_list
+
+
+class Writer:
+    "Minimal Makefile Writter"
+
+    def __init__(self, output: IO, width: int = 78):
+        self.output = output
+        self.width = width
+
+    def _line(self, text: str) -> None:
+        for line in textwrap.wrap(text,
+                                  break_long_words=False,
+                                  break_on_hyphens=False,
+                                  subsequent_indent='  '):
+            self.output.write(line + " \\\n")
+        self.newline()
+
+    def newline(self) -> None:
+        "Emit a new line"
+        self.output.write('\n')
+
+    def comment(self, text) -> None:
+        "Emit a comment"
+        for line in textwrap.wrap(text,
+                                  self.width - 2,
+                                  break_long_words=False,
+                                  break_on_hyphens=False):
+            self.output.write('# ' + line + '\n')
+
+    def simple_dep(self, outputs: Union[str, List[str]], inputs: Union[str, List[str]]) -> None:
+        "Emit a simple dependency without build rules"
+        outputs = as_list(outputs)
+        inputs = as_list(inputs)
+
+        self._line('%s: %s' % (' '.join(outputs), ' '.join(inputs)))
+
+    def close(self) -> None:
+        "Close the output file"
+        self.output.close()

--- a/moulin/utils.py
+++ b/moulin/utils.py
@@ -3,6 +3,7 @@
 """Module hosting different utility functions"""
 
 import os.path
+import sys
 
 
 def create_stamp_name(*args):
@@ -10,3 +11,10 @@ def create_stamp_name(*args):
     stamp = "-".join(args)
     path = os.path.join(".stamps", stamp.replace("-", "--").replace(os.sep, "-").replace(":", "-"))
     return os.path.abspath(path)
+
+
+def construct_fetcher_dep_cmd() -> str:
+    "Generate command line to generate fetcher dependency file"
+    this_script = os.path.abspath(sys.argv[0])
+    args = " ".join(sys.argv[1:])
+    return f"{this_script} {args} --fetcherdep $name"


### PR DESCRIPTION
Ninja supports two ways to discover dynamic dependencies:

 - dyndep mechanism - it is used to discover mandatory dependencies
   *before* build
 - deps mechanism - it is used to discover optional dependencies
   *during* build. It is used mostly to track dependencies between
   C source files and header files they include

Prior to this patch, Moulin used the dyndep mechanism. But it appears
that it does not cope will with removing or renaming files. As those
type of dependencies are mandatory, Ninja will complain that it does
not know how to build removed file.

So, only one way to fix this is to move to "deps" mechanism. This is
exactly what this patch does.
