### PR TITLE
Introducing new parameter to rouge: gpt_uuid

### DIFF
--- a/docs/rouge.rst
+++ b/docs/rouge.rst
@@ -284,6 +284,7 @@ virtual machines and wish to provide VM with own GPT.
    partitions:
      boot: # partition label
        gpt_type: 21686148-6449-6E6F-744E-656564454649 # BIOS boot partition (kinda...)
+       gpt_guid: 8DA63339-0007-60C0-C436-083AC8230900 # Partition GUID
        type: empty
        size: 30 MiB
      rootfs:
@@ -298,12 +299,22 @@ includes Raw Image block.
 :code:`partitions:` section is mandatory. It defines list of
 partitions, where key is a partition label.
 
-Each partition contains definition of other block type plus optional
-(but we strongly suggest to provide it) key :code:`gpt_type:`. This
-key holds GPT Partition Type GUID. List of widely used types can be
-found on
+Each partition contains definition of other block type plus optional keys:
+
+:code:`gpt_type:` (which we strongly suggest to provide) key holds GPT Partition
+Type GUID. List of widely used types can be found on
 `Wikipedia <https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs>`_,
 for example.
+
+:code:`gpt_guid:` key sets the GPT Partition GUID. By default this GUID is generated
+automatically to ensure that every partition in the world would have unique
+identifier. But there are some cases when external software depends on exact value
+of a partition GUID. In such cases it is possible to hard-code this value. We
+strongly recommend not to use this key except for the cases when this is neccessary
+because, accoding to the page 121 of
+`Specification <https://uefi.org/sites/default/files/resources/UEFI_Spec_2_8_final.pdf>`_
+the software that makes copied of GPT-formatted disks and partitions must generate
+new Unique Partition GUID in each GPT Partition Entry.
 
 `rouge` will place partitions one after another, aligning partition
 start to 1 MiB (as per standard recommendation) and partition size to
@@ -343,6 +354,7 @@ The following example provides multiple different images:
              "initrd": "yocto/build/tmp/deploy/images/generic-armv8-xt/uInitrd"
          domd_rootfs:
            gpt_type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE # Linux aarch64 root
+           gpt_guid: 8DA63339-0007-60C0-C436-083AC8230900 # Partition GUID
            type: raw_image
            image_path: "yocto/build-domd/tmp/deploy/images/machine/core-image-weston.ext4"
 

--- a/moulin/rouge/block_entry.py
+++ b/moulin/rouge/block_entry.py
@@ -37,6 +37,7 @@ class GPTPartition(NamedTuple):
     "Represents one partition in GPT"
     label: str
     gpt_type: str
+    gpt_guid: str
     start: int
     size: int
     entry: BlockEntry
@@ -51,8 +52,8 @@ class GPT(BlockEntry):
 
         for part_id, part in node["partitions"].items():
             label = part_id
-            entry_obj, gpt_type = self._process_entry(part)
-            self._partitions.append(GPTPartition(label, gpt_type, start=0, size=0, entry=entry_obj))
+            entry_obj, gpt_type, gpt_guid = self._process_entry(part)
+            self._partitions.append(GPTPartition(label, gpt_type, gpt_guid, start=0, size=0, entry=entry_obj))
 
     def size(self) -> int:
         "Returns size in bytes"
@@ -68,7 +69,9 @@ class GPT(BlockEntry):
             log.warning("No GPT type is provided %s, using default", node.mark)
             gpt_type = "8DA63339-0007-60C0-C436-083AC8230908"
 
-        return (entry_obj, gpt_type)
+        gpt_guid = node.get("gpt_guid", "").as_str
+
+        return (entry_obj, gpt_type, gpt_guid)
 
     def _complete_init(self):
         partitions = [x._replace(size=x.entry.size()) for x in self._partitions]

--- a/moulin/rouge/sfdisk.py
+++ b/moulin/rouge/sfdisk.py
@@ -31,10 +31,15 @@ def _align(val, align) -> int:
 def _to_script(part: Any, sector_size=512) -> str:
     "Convert GPT Partition object to sfdisk script line"
 
-    return ", ".join([
+    args = [
         f"start={_sect(part.start, sector_size)}", f"size={_sect(part.size, sector_size)}",
         f"type={part.gpt_type}", f"name={part.label}"
-    ])
+    ]
+
+    if part.gpt_guid:
+        args.append(f"uuid={part.gpt_guid}")
+
+    return ", ".join(args)
 
 
 def _check_sfdisk():


### PR DESCRIPTION
gpt_uuid parameter is intendend to set UUID for gpt partitions. Partition UUID can be used to mount partition from fstab regardless of the storage type.