### PR TITLE
rouge: fix partition alignment

### DIFF
--- a/moulin/rouge/sfdisk.py
+++ b/moulin/rouge/sfdisk.py
@@ -65,7 +65,7 @@ def fixup_partition_table(partitions: List[Any], sector_size=512) -> Tuple[List[
     end = start_offset * sector_size
     ret = []
     for part in partitions:
-        start = _align(end + 1, DEFAULT_ALIGNMENT)  # Align to 1 MB
+        start = _align(end, DEFAULT_ALIGNMENT)  # Align to 1 MB
         size = _align(part.size, sector_size)
         ret.append(part._replace(start=start, size=size))
         end = start + size


### PR DESCRIPTION
Do not add 1 additional sector to the end of each partition, as this
would unnecessarily add space between partitions that are already
aligned to DEFAULT_ALIGNMENT. Selection of 'next sector' is already
done by start + size calculation.

This avoids wasting space and allows to align the first partition
exactly to DEFAULT_ALIGNMENT (and not to DEFAULT_ALIGNMENT + 2048,
as it is now).

Signed-off-by: Francesco Valla <francesco.valla@mta.it>