### PR TITLE
builders: fix `zephyr` builder

### DIFF
--- a/moulin/builders/zephyr.py
+++ b/moulin/builders/zephyr.py
@@ -27,6 +27,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
         # Generate fetcher dependency file
         construct_fetcher_dep_cmd(),
         "cd $build_dir/zephyr",
+        "source zephyr-env.sh",
         "west build -p auto -b $board $target",
     ])
     generator.rule("zephyr_build",


### PR DESCRIPTION
For correct build we need to set proper environment.

Fixes: b42ac8cb54ebf8b5d9842985e1f127db47bdea0c
