### PR TITLE
rouge: add possibility to specify size of image

### DIFF
--- a/docs/rouge.rst
+++ b/docs/rouge.rst
@@ -182,7 +182,7 @@ defines empty block with size of 4096 bytes. `rouge` supports some SI suffixes:
  - :code:`GiB` - gibibyte - 1024 mebibytes or 1 073 741 824 bytes
 
 Suffix must be separated from number by space. For example:
-:code:`size: 4 MiB` defines size of 4 mebibytes or 4 194 304 bytes.
+:code:`size: 4 MiB` defines size of 4 mebibytes or 4 194 304 bytes.
 
 Empty block
 ^^^^^^^^^^^

--- a/docs/rouge.rst
+++ b/docs/rouge.rst
@@ -127,6 +127,7 @@ Images are specified in the following way:
    images:
      image_name_a:
        desc: "Description for the first image"
+       image_size: 512 MiB
        type: gpt
        ... block description ...
      image_name_b:
@@ -144,6 +145,14 @@ image names. Every image can have description, which will be displayed
 when `rouge` lists available images. :code:`type:` key is mandatory as
 it defines type of block. Supported block types as described in the
 following sections.
+
+Also you may specify the required size of image using
+:code:`image_size:`. Please see section 'Size Designation' below for
+supported notation. If actual size of all partitions will be less than
+:code:`image_size:` then image will be blown up to :code:`image_size:`.
+If actual size is bigger than specified - error will be printed with
+explanation like "Actual size (20000) of image is bigger than requested
+one (10000)."
 
 Block descriptions
 ------------------


### PR DESCRIPTION
For some cases we need to have image of certain size despite sizes of internal partitions.

This PR adds `image_size` field to image descriptor. If it is not specified or zero, then image is created taking into account internal partitions.
If actual size of partitions is bigger than `image_size` - error is raised, that we can't create image of specified size.
