### PR TITLE
rouge: add possibility to fill partition by zeroes

### DIFF
--- a/docs/rouge.rst
+++ b/docs/rouge.rst
@@ -187,15 +187,23 @@ Suffix must be separated from number by space. For example:
 Empty block
 ^^^^^^^^^^^
 
-Empty block is a block that is not filled with any
-information. `rouge` will write nothing into this block.
+Empty block is a block that does not contain any file or
+raw image. `rouge` will write nothing into this block if
+:code:`filled: zeroes` option is not specified.
 
 .. code-block:: yaml
 
    type: empty # defines empty block
    size: 4096
+   filled: zeroes
 
 :code:`size` is mandatory, as `rouge` can't infer it.
+
+:code:`filled` is optional, with only `zeroes` value allowed for now.
+This option may be used if you need the block to be filled with zeroes.
+For example, this is used for some Android partitions, like 'rpmbemul'.
+Use this option only if you really need to. Otherwise you will needlessly
+increase size and upload time of an image.
 
 .. _rouge-raw-image-block:
 

--- a/moulin/rouge/block_entry.py
+++ b/moulin/rouge/block_entry.py
@@ -214,10 +214,15 @@ class EmptyEntry(BlockEntry):
 
     def __init__(self, node: YamlValue):
         self._size = _parse_size(node["size"])
+        self._fill_by_zero = (node.get("filled", "").as_str == "zeroes")
 
     def size(self) -> int:
         "Returns size in bytes"
         return self._size
+
+    def write(self, fp, offset):
+        if self._fill_by_zero:
+            ext_utils.dd("/dev/zero", fp, offset, out_size=self._size)
 
 
 class FileSystem(BlockEntry):

--- a/moulin/rouge/ext_utils.py
+++ b/moulin/rouge/ext_utils.py
@@ -4,7 +4,7 @@
 External utils interfaces/wrappers for rouge image builder
 """
 
-from typing import BinaryIO, Union
+from typing import BinaryIO, Union, Optional
 import subprocess
 import logging
 
@@ -17,7 +17,7 @@ def _run_cmd(args):
 
 
 # pylint: disable=invalid-name
-def dd(file_in: Union[str, BinaryIO], file_out: BinaryIO, out_offset: int):
+def dd(file_in: Union[str, BinaryIO], file_out: BinaryIO, out_offset: int, out_size: Optional[int] = None):
     "Run dd with the given arguments"
     # Try to guess block size. We would like to use as big block as
     # possible. But we need take into account that "seek" parameter
@@ -40,6 +40,8 @@ def dd(file_in: Union[str, BinaryIO], file_out: BinaryIO, out_offset: int):
         "conv=sparse",
         "conv=notrunc",
     ]  # yapf: disable
+    if out_size:
+        args.append(f"count={out_size // blocksize}")
     _run_cmd(args)
 
 


### PR DESCRIPTION
Commit adds optional `filled: zeroes` field to Empty block.

```
  rpmbemul:
    gpt_type: DC76DDA9-5AC1-491C-AF42-A82591580C0D # Android data
    type: empty
    size: 1 MiB
    filled: zeroes
```

Such partitions are used by Android, like 'rpmbemul' and 'misc'.