### PR TITLE
Fix repo fetcher, yaml_wrapper and rework as_str

### DIFF
--- a/moulin/fetchers/repo.py
+++ b/moulin/fetchers/repo.py
@@ -55,7 +55,7 @@ class RepoFetcher:
         rev = self.conf.get("rev", "").as_str
         if rev:
             repo_args.append(f"-b {shlex.quote(rev)}")
-        depth = self.conf.get("depth", "").as_int
+        depth = self.conf.get("depth", 0).as_int
         if depth:
             repo_args.append(f"--depth={depth}")
         groups = self.conf.get("groups", "").as_str

--- a/moulin/yaml_wrapper.py
+++ b/moulin/yaml_wrapper.py
@@ -38,21 +38,21 @@ class _YamlDefaultValue:
     def as_str(self) -> str:
         "Get the string value"
         if not isinstance(self._val, str):
-            raise TypeError("Expected boolean value")
+            raise TypeError("Expected string value")
         return self._val
 
     @property
     def as_int(self) -> int:
         "Get the integer value"
         if not isinstance(self._val, int):
-            raise TypeError("Expected boolean value")
+            raise TypeError("Expected int value")
         return self._val
 
     @property
     def as_float(self) -> float:
         "Get the floating point value"
         if not isinstance(self._val, int):
-            raise TypeError("Expected boolean value")
+            raise TypeError("Expected float value")
         return self._val
 
 
@@ -94,7 +94,7 @@ class YamlValue:  # pylint: disable=too-few-public-methods
     @property
     def as_float(self) -> float:
         "Get the floating point value"
-        if not isinstance(self._val, int):
+        if not isinstance(self._val, float):
             raise YAMLProcessingError(f"Expected floating point value, got {type(self._val)}",
                                       self.mark)
         return self._val


### PR DESCRIPTION
This PR contains two fixing commits:
- yaml_wrapper: fix copy-paste errors in yaml_wrapper
- fetchers: fix default value for depth

The third commit is proposed for discussion because it changes the behavior of as_str(). My points are explained in the commit message and as comments inside the code.
- yaml_wrapper: allow as_str() to accept any data type