### PR TITLE
zephyr: add `env` option to builder

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -572,6 +572,9 @@ to be fetched by `west` fetcher.
     target: samples/synchronization
     target_images:
       - "zephyr/build/zephyr/zephyr.bin"
+    env:
+      - "MY_ENV_VAR=my_value"
+
 
 Mandatory options:
 
@@ -589,6 +592,11 @@ Mandatory options:
 * :code:`target_images` - list of image files that should be generated
   by this builder. For standard build, it is expected to be
   "zephyr/build/zephyr/zephyr.bin"
+
+Optional parameters:
+
+* :code:`env` - list of additional environment variables that should
+  be exported before calling :code:`west build`.
 
 Please note that this builder uses :code:`--pristine=auto` command-line option.
 

--- a/moulin/builders/zephyr.py
+++ b/moulin/builders/zephyr.py
@@ -28,7 +28,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
         construct_fetcher_dep_cmd(),
         "cd $build_dir/zephyr",
         "source zephyr-env.sh",
-        "west build -p auto -b $board $target",
+        "$env west build -p auto -b $board $target",
     ])
     generator.rule("zephyr_build",
                    command=f'bash -c "{cmd}"',
@@ -54,11 +54,20 @@ class ZephyrBuilder:
 
     def gen_build(self):
         """Generate Ninja rules to build Zephyr"""
+
+        env_node = self.conf.get("env", None)
+        if env_node:
+            env_values = [x.as_str for x in env_node]
+        else:
+            env_values = []
+        env = " ".join(env_values)
+
         variables = {
             "name": self.name,
             "build_dir": self.build_dir,
             "board": self.conf["board"].as_str,
             "target": self.conf["target"].as_str,
+            "env": env,
         }
         targets = self.get_targets()
         deps = list(self.src_stamps)


### PR DESCRIPTION
This option allows to provide custom environment variable available during build of Zephyr application.

Example of usage:

```
    builder:
      type: zephyr
      <...>
      env:
        - "MY_ENV_VAR=my_value"
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>