### PR TITLE
Update syntax for EXTERNALSRC_pn-{key}

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2022, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.11'
+release = 'v0.12'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -442,7 +442,7 @@ needed if you are building multiple VMs with cross-dependencies.
 
 * :code:`external_src` - list of external sources for packages. This
   option will make `moulin` to generate
-  :code:`EXTERNALSRC_pn-{package}` in `local.conf`. This feature is
+  :code:`EXTERNALSRC:pn-{package}` in `local.conf`. This feature is
   used to provide Yocto build with artifacts that were built outside
   of the tree. Such artifacts can be provided by another component,
   for example.

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -132,7 +132,7 @@ class YoctoBuilder:
             else:
                 path = val_node.as_str
             path = os.path.abspath(path)
-            ret.append((f"EXTERNALSRC_pn-{key}", path))
+            ret.append((f"EXTERNALSRC:pn-{key}", path))
 
         return ret
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.11',  # Required
+    version='0.12',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Since the Honister release the "_" character needs to be replaced with ":".

In particular, wrong syntax in that variable(s) being written to moulin.conf leads to the domd.bb(domu.dd):do_install tasks failure.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>