### PR TITLE
add options to zephyr builder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'moulin'
-copyright = '2021-2022, EPAM Systems'
+copyright = '2021-2023, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.12'
+release = 'v0.13'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -570,6 +570,7 @@ to be fetched by `west` fetcher.
     type: zephyr
     board: xenvm
     target: samples/synchronization
+    work_dir: build_dir
     target_images:
       - "zephyr/build/zephyr/zephyr.bin"
     env:
@@ -597,6 +598,9 @@ Optional parameters:
 
 * :code:`env` - list of additional environment variables that should
   be exported before calling :code:`west build`.
+
+* :code:`work_dir` - build system's work directory. Default value is
+  "build". This is where files produced by build system are stored.
 
 Please note that this builder uses :code:`--pristine=auto` command-line option.
 

--- a/moulin/builders/zephyr.py
+++ b/moulin/builders/zephyr.py
@@ -26,9 +26,9 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     cmd = " && ".join([
         # Generate fetcher dependency file
         construct_fetcher_dep_cmd(),
-        "cd $build_dir/zephyr",
-        "source zephyr-env.sh",
-        "$env west build -p auto -b $board $target",
+        "cd $build_dir",
+        "source zephyr/zephyr-env.sh",
+        "$env west build -p auto -b $board -d $work_dir $target",
     ])
     generator.rule("zephyr_build",
                    command=f'bash -c "{cmd}"',
@@ -67,6 +67,7 @@ class ZephyrBuilder:
             "build_dir": self.build_dir,
             "board": self.conf["board"].as_str,
             "target": self.conf["target"].as_str,
+            "work_dir": self.conf.get("work_dir", "zephyr/build").as_str,
             "env": env,
         }
         targets = self.get_targets()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.12',  # Required
+    version='0.13',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
work_dir option allows build out-of-tree zephyr applicaton target option made optional.