### PR TITLE
doc: fix file extension for `archive` builder

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -538,7 +538,7 @@ as, `tar` is invoked with `--auto-compress` option.
 
   builder:
     type: archive        # Should be 'artchive'
-    name: "artifacts.tar.bz"
+    name: "artifacts.tar.bz2"
     items:
       - "yocto/build/tmp/deploy/images/generic-armv8-xt/Image"
       - "yocto/build/tmp/deploy/images/generic-armv8-xt/uInitramfs"


### PR DESCRIPTION
According to the documentation for `tar --auto-compress` extension `tar.bz` is not supported. So replace it with `tar.bz2`.