### PR TITLE
builders: archive: introduce tar's base dir

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2023, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.15'
+release = 'v0.16'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -529,7 +529,7 @@ Optional parameters:
 archive builder
 ^^^^^^^^^^^^^^^
 
-Archive builder does is intended to create archive from other components.
+Archive builder is intended to create an archive from other components.
 It can be used to gather build artifacts, for example. This builder
 uses `tar` to create archive files. Archives can be optionally compressed
 as, `tar` is invoked with `--auto-compress` option.
@@ -537,7 +537,7 @@ as, `tar` is invoked with `--auto-compress` option.
 .. code-block:: yaml
 
   builder:
-    type: archive        # Should be 'artchive'
+    type: archive        # Should be 'archive'
     name: "artifacts.tar.bz2"
     items:
       - "yocto/build/tmp/deploy/images/generic-armv8-xt/Image"
@@ -545,16 +545,16 @@ as, `tar` is invoked with `--auto-compress` option.
 
 Mandatory options:
 
-* :code:`type` - Builder type. Should be :code:`archive` for this type
+* :code:`type` - Builder type. It should be :code:`archive` for this type
   of builder.
 
-* :code:`name` - Name of archive file. Add suffix like `tar.bz2` to
+* :code:`name` - Name of an archive file. Add a suffix like `tar.bz2` to
   make `tar` compress archive with desired compressing algorithm.
 
 * :code:`items` - list of files or directories that should be added
-  do the archive. Please ensure that those files or directories present
+  to the archive. Please ensure that those files or directories are present
   in other components :code:`target_images` sections, so Ninja can
-  build correct dependencies. All paths are relative to base build
+  build correct dependencies. All paths are relative to the base build
   directory (where .yaml file resides).
 
 zephyr builder

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -539,9 +539,11 @@ as, `tar` is invoked with `--auto-compress` option.
   builder:
     type: archive        # Should be 'archive'
     name: "artifacts.tar.bz2"
+    base_dir: "yocto/build/tmp/deploy/images/"
     items:
-      - "yocto/build/tmp/deploy/images/generic-armv8-xt/Image"
-      - "yocto/build/tmp/deploy/images/generic-armv8-xt/uInitramfs"
+      # items are relative to base_dir
+      - "generic-armv8-xt/Image"
+      - "generic-armv8-xt/uInitramfs"
 
 Mandatory options:
 
@@ -551,11 +553,17 @@ Mandatory options:
 * :code:`name` - Name of an archive file. Add a suffix like `tar.bz2` to
   make `tar` compress archive with desired compressing algorithm.
 
+* :code:`base_dir` - Optional parameter specifying `tar`'s base directory.
+  The default value is "." if not specified. This is passed to `tar` as
+  `-C` option. As result, the final archive will contain paths relative
+  to :code:`base_dir`. Avoid using `..` because specified items will be
+  archived by `tar` but all `..` will be stripped. As a result, the archive
+  will contain items with unexpected paths.
+
 * :code:`items` - list of files or directories that should be added
   to the archive. Please ensure that those files or directories are present
   in other components :code:`target_images` sections, so Ninja can
-  build correct dependencies. All paths are relative to the base build
-  directory (where .yaml file resides).
+  build correct dependencies. All paths are relative to the :code:`base_dir`.
 
 zephyr builder
 ^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.15',  # Required
+    version='0.16',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This commit solves an issue that archives created by the archive builder
contain paths to files relative to build-dir. As result, paths may
contain a long list of build-related directories, and in some cases, this
is not desirable.
A possible solution is to specify desired starting point as build dir,
but this will put the resulting archive into the same directory.
So, the best way to get an archive in the top directory and get rid of
intermediate directories - is to specify the base directory for `tar`
through the `-C` option.

That's why this commit introduces the `base_dir` field for the archive
builder. The `base_dir` is an optional field, and it has '.' value if
not provided.