### PR TITLE
github workflow: install requirements from setup.py

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,15 +16,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v3
-      with:
-        python-version: 3.6.15
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest pyaml
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python3 -m pip install --upgrade pip
+        pip3 install flake8 pytest pyaml
+        # Needed by pygit package
+        sudo apt-get install python3-pygit2
+        # Install other dependencies from setup.py
+        pip3 install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Default github workflow sample uses requirements.txt to install required packages, but we are using more moder approach with setup.py, so wee need to install requirements in the different way.