### PR TITLE
raise exception when have ambiguousness of revisions

### DIFF
--- a/moulin.py
+++ b/moulin.py
@@ -10,7 +10,10 @@ from moulin.main import moulin_entry
 
 
 def main():
-    moulin_entry()
+    try:
+        moulin_entry()
+    except Exception as err:
+        print(err)
 
 
 if __name__ == "__main__":

--- a/moulin/fetchers/git.py
+++ b/moulin/fetchers/git.py
@@ -44,7 +44,7 @@ def _guess_dirname(url: str):
     return url.split("/")[-1]
 
 
-_SEEN_REPOS = []
+_SEEN_REPOS_REV = {}
 
 
 class GitFetcher:
@@ -64,10 +64,15 @@ class GitFetcher:
         checkout_stamp = create_stamp_name(self.build_dir, self.url, "checkout")
 
         # Do not checkout repos for the second time
-        if checkout_stamp in _SEEN_REPOS:
-            return checkout_stamp
+        if checkout_stamp in _SEEN_REPOS_REV:
+            if self.git_rev != _SEEN_REPOS_REV[checkout_stamp]:
+                raise Exception(f"ERROR: Repository {self.url} has two\
+ revisions '{self.git_rev}' and '{_SEEN_REPOS_REV[checkout_stamp]}'")
+            else:
+                return checkout_stamp
 
-        _SEEN_REPOS.append(checkout_stamp)
+        _SEEN_REPOS_REV[checkout_stamp] = self.git_rev
+
         self.generator.build(clone_target,
                              "git_clone",
                              variables={


### PR DESCRIPTION
yaml file may have some ambiguousness of revisions, for example .....
domd:
    sources:
      - type: git url: "https://github.com/good/meta-good" .....
--ENABLE_SOMETHING
      default: no
      ......
         components:
            domd:
              sources:
                - type: git url: "https://github.com/good/meta-good" rev: main Here we have one repository but with the two different revisions. At this moment, moulin checks if url has been fetched and skip all the overrides. It means that build may have unexpected result. The patch check if the repos exists and if the revisions are the same. If revisions are not the same -  throws the exception.