### PR TITLE
rouge: mkvfatfs() hotfix

### DIFF
--- a/moulin/rouge/ext_utils.py
+++ b/moulin/rouge/ext_utils.py
@@ -73,7 +73,8 @@ def mkvfatfs(file_out: BinaryIO, sector_size=None):
     "Create FAT fs in given file"
     args = ["mkfs.vfat"]
     if sector_size:
-        args.append(f"-S {sector_size}")
+        args.append("-S")
+        args.append(str(sector_size))
     args.append(file_out.name)
 
     _run_cmd(args)


### PR DESCRIPTION
f-strings does not work well for mkfs.vfat external ulility. E.g. on Ubuntu 22.04 these failures observed:

[..]
	[INFO] Running mkfs.vfat -S 4096 /tmp/tmpysgqa_7m
	mkfs.fat 4.2 (2021-01-31)
	Bad logical sector size :  4096
	Usage: mkfs.vfat [OPTIONS] TARGET [BLOCKS]
[..]

Neighbour code for similar cases just uses double .append(), so we'd better stick with this approach.