### PR TITLE
rouge: generate target for LZMA packed image (.xz)

### DIFF
--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -22,8 +22,8 @@ will also generate handy :code:`image-{image_name}` rules. They can be
 used to invoke :code:`rouge` with the same build options, as
 :code:`moulin` was invoked.
 
-Moulin also generates :code:`{image_name}.img.gz` and :code:`{image_name}.img.bmap`
-targets.
+Moulin also generates :code:`{image_name}.img.gz`, :code:`{image_name}.img.xz`
+and :code:`{image_name}.img.bmap` targets.
 
 Build inside yocto
 ------------------

--- a/moulin/rouge/__init__.py
+++ b/moulin/rouge/__init__.py
@@ -38,6 +38,8 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     generator.newline()
     generator.rule("gzip", "gzip -1kf $in")
     generator.newline()
+    generator.rule("lzma", "xz -1kf $in")
+    generator.newline()
     generator.rule("bmaptool", "bmaptool create $in -o $out")
     generator.newline()
 
@@ -53,6 +55,10 @@ def gen_build(generator: ninja_syntax.Writer, images: List[RougeImage]):
                         pool="console")
         generator.build(f"{image.name}.img.gz",
                         "gzip",
+                        f"{image.name}.img",
+                        pool="console")
+        generator.build(f"{image.name}.img.xz",
+                        "lzma",
                         f"{image.name}.img",
                         pool="console")
         generator.build(f"{image.name}.img.bmap",


### PR DESCRIPTION
Archives packed by LZMA (`xz`) can be read without unpacking the full archive.
External tools may use this feature to flash images directly from the *.xz file.