### PR TITLE
yocto.py: Support aliases for specifying 'layers' 

### DIFF
--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -93,7 +93,7 @@ def _flatten_yocto_conf(conf: YamlValue) -> List[Tuple[str, str]]:
     result: List[Tuple[str, str]] = []
     for entry in conf:
         if not entry.is_list:
-            raise YAMLProcessingError("Exptected array on 'conf' node", entry.mark)
+            raise YAMLProcessingError("Expected array on 'conf' node", entry.mark)
         if entry[0].is_list:
             result.extend([(x[0].as_str, x[1].as_str) for x in entry])
         else:

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -101,6 +101,34 @@ def _flatten_yocto_conf(conf: YamlValue) -> List[Tuple[str, str]]:
     return result
 
 
+def _flatten_layers(layers_node: YamlValue) -> List[str]:
+    """
+Flattens a YAML structure representing layers into a list of strings.
+This function takes a YAML node representing layers and flattens it into a list of strings.
+It processes the input YAML structure, extracting individual layer names as strings and adding
+them to the resulting list.
+Args:
+    layers_node (YamlValue): The YAML node, represents a list of layers.
+Returns:
+    List[str]: A list of strings, each string represents a layer name.
+Example:
+    If `layers_node` is a YAML list like this:
+    -
+     - nested_layer1
+     - nested_layer2
+    - layer3
+    - layer4
+    The function will return ['nested_layer1', 'nested_layer2', 'layer3', 'layer4']
+"""
+    result: List[str] = []
+    for entry in layers_node:
+        if entry.is_list:
+            result.extend([(x.as_str) for x in entry])
+        else:
+            result.append((entry.as_str))
+    return result
+
+
 class YoctoBuilder:
     """
     YoctoBuilder class generates Ninja rules for given build configuration
@@ -154,7 +182,7 @@ class YoctoBuilder:
         layers_node = self.conf.get("layers", None)
         if layers_node:
             layers_stamp = create_stamp_name(self.yocto_dir, self.work_dir, "yocto", "layers")
-            layers = " ".join([x.as_str for x in layers_node])
+            layers = " ".join(_flatten_layers(layers_node))
             self.generator.build(layers_stamp,
                                  "yocto_add_layers",
                                  env_target,


### PR DESCRIPTION
```
...
      common_layers: &COMMON_LAYERS
            - "layer1"
            - "layer2"
...
components:
    comp0:
         builder:
             layers:
                 - *COMMON_LAYERS
                 - "layer3"
                 - "layer4"
```

The issue is that if an alias appears inside the 'layers' key, the
alias reaches us as an empty node without a value but with a child.
It's the same as writing:

```
layers:
     -
        - "nested_layer1"
        - "nested_layer2"
     - "layer3"
     - "layer4"
```

And there is no way to step over this on the yaml level, e.g. using
some other syntax.

To make the "layers" component combinable with a variable, as in
the example above, the changes were made to the yocto.py file.
The function _flatten_layers has been added. It processes an input YAML
structure, extracting the names of individual layers as strings and
appending them to the resulting list.
The function will return:
['nested_layer1', 'nested_layer2', 'layer3', 'layer4']

Now the above empty node is unfolded for this specific case, and the
proper data is fetched by the moulin.