### PR TITLE
git.py: Unlink checkout target from the repo dir

### DIFF
--- a/moulin/fetchers/git.py
+++ b/moulin/fetchers/git.py
@@ -69,6 +69,7 @@ class GitFetcher:
     def gen_fetch(self):
         """Generate instruction to fetch git repo"""
         clone_target = self.git_dir
+        clone_stamp = create_stamp_name(self.build_dir, self.url, "clone")
         checkout_stamp = create_stamp_name(self.build_dir, self.url, "checkout")
 
         if checkout_stamp in _SEEN_REPOS_REV:
@@ -82,7 +83,7 @@ class GitFetcher:
 
         _SEEN_REPOS_REV[checkout_stamp] = self.git_rev
 
-        self.generator.build(clone_target,
+        self.generator.build([clone_target, clone_stamp],
                              "git_clone",
                              variables={
                                  "git_url": self.url,
@@ -91,7 +92,7 @@ class GitFetcher:
         self.generator.newline()
         self.generator.build(checkout_stamp,
                              "git_checkout",
-                             clone_target,
+                             clone_stamp,
                              variables={
                                  "git_rev": self.git_rev,
                                  "git_dir": self.git_dir


### PR DESCRIPTION
Change the behavior of the git fetcher so that it doesn't apply the checkout operation again, when the repository root folder is changed manually by the user.

The git.py file has been modified. Сhanges were made to the gen_fetch function.

Previous dependency chain was:

- git_clone rule generates repository folder as an $out parameter
- git_checkout usage depends on the same repository folder

With it the change of the folder by the user leads to a side-effect, as git_checkout_stamp file marker becomes 'dirty'.

This patch changes the dependency chain to:

- git_clone rule generates repository folder AND a git_clone_stamp file marker as an $out parameter. 2 output artifacts
- git_checkout usage depends on the git_clone_stamp file marker

With this approach change of the folder by the user does not affect the state of the artifact generated by the git_checkout rule.

Still, if the repository folder would be deleted, it will cause application of both git_clone and git_checkout operations.

With this patch, when the root directory of any git-fetcher related project is manually updated, the build system will not jump back to the branch, defined in the YAML file.