### PR TITLE
git.py: added directory tracking to the Moulin git builder

### DIFF
--- a/moulin/fetchers/git.py
+++ b/moulin/fetchers/git.py
@@ -75,7 +75,8 @@ class GitFetcher:
         if checkout_stamp in _SEEN_REPOS_REV:
             if self.git_rev != _SEEN_REPOS_REV[checkout_stamp]:
                 # Fail on occurrence of different revision for the already downloaded repository
-                raise YAMLProcessingError(f"ERROR: Repository {self.url} has two revisions '{self.git_rev}' "
+                raise YAMLProcessingError(f"ERROR: Repository {self.url} cloned to '{clone_target}' "
+                                          f"has two revisions '{self.git_rev}' "
                                           f"and '{_SEEN_REPOS_REV[checkout_stamp]}'", self.conf["rev"].mark)
             else:
                 # Do not checkout repos for the second time

--- a/moulin/fetchers/git.py
+++ b/moulin/fetchers/git.py
@@ -69,8 +69,8 @@ class GitFetcher:
     def gen_fetch(self):
         """Generate instruction to fetch git repo"""
         clone_target = self.git_dir
-        clone_stamp = create_stamp_name(self.build_dir, self.url, "clone")
-        checkout_stamp = create_stamp_name(self.build_dir, self.url, "checkout")
+        clone_stamp = create_stamp_name(self.build_dir, clone_target, self.url, "clone")
+        checkout_stamp = create_stamp_name(self.build_dir, clone_target, self.url, "checkout")
 
         if checkout_stamp in _SEEN_REPOS_REV:
             if self.git_rev != _SEEN_REPOS_REV[checkout_stamp]:


### PR DESCRIPTION
Change the behavior of the git fetcher so that it doesn't consider two
or more occurrences of the same git repository in the moulin *.yaml
configuration file as an error if the duplicated repository is cloned
into different sub-folders within the build directory.
For example:
 
```
  domd:
     sources:
      - type: git
        url: "https://github.com/xen-troops/meta-example.git"
        rev: ABCDEF
        dir: "dir1"
  domu:    
    sources:
      - type: git
        url: "https://github.com/xen-troops/meta-example.git"
        rev: branch_A
        dir: "dir2"
```

Above, identical repositories have different branches. But, also, they
have different 'dir' parameters. So that would not be considered as an
error.
 
But if they would have identical directories - the error still will be
triggered.