### PR TITLE
custom_script: Make the 'args' parameter optional

### DIFF
--- a/moulin/builders/custom_script.py
+++ b/moulin/builders/custom_script.py
@@ -87,11 +87,14 @@ class CustomScriptBuilder:
         self.generator.build(f"conf-{self.name}", "phony", local_conf_target)
         self.generator.newline()
 
-        args_node = self.conf.get("args", "")
-        if args_node.is_list:
-            args = " ".join([x.as_str for x in args_node])
+        args_node = self.conf.get("args", None)
+        if args_node:
+            if args_node.is_list:
+                args = " ".join([x.as_str for x in args_node])
+            else:
+                args = args_node.as_str
         else:
-            args = args_node.as_str
+            args = ""
         self.generator.build(targets, "cs_build", deps, variables=dict(
             common_variables,
             config_file=local_conf_file,

--- a/tests/integration_tests/custom_script_builder/resources/script.sh
+++ b/tests/integration_tests/custom_script_builder/resources/script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$1" == "-list" ]; then
+    echo "list"
+elif [ "$1" == "-string" ]; then
+    echo "string"
+else
+    echo "No arguments"
+fi

--- a/tests/integration_tests/custom_script_builder/test_args_is_list/resources/test_args_is_list.yaml
+++ b/tests/integration_tests/custom_script_builder/test_args_is_list/resources/test_args_is_list.yaml
@@ -1,0 +1,13 @@
+desc: "Test args parameter missing"
+min_ver: "0.20"
+
+components:
+  test:
+    builder:
+      type: custom_script
+      script: "../../resources/script.sh"
+      args:
+        - "-list"
+      target_images:
+        - "Image"
+

--- a/tests/integration_tests/custom_script_builder/test_args_is_list/test_args_is_list.py
+++ b/tests/integration_tests/custom_script_builder/test_args_is_list/test_args_is_list.py
@@ -1,0 +1,32 @@
+import subprocess
+import pytest
+import os
+import tempfile
+
+
+@pytest.mark.integration
+def test_args_is_list():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/test_args_is_list.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is not equal to '0'")
+
+        result = subprocess.run(["ninja"],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is not equal to '0'")
+        assert "list" not in result.stderr, "The expected arguments are missing"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/integration_tests/custom_script_builder/test_args_is_string/resources/test_args_is_string.yaml
+++ b/tests/integration_tests/custom_script_builder/test_args_is_string/resources/test_args_is_string.yaml
@@ -1,0 +1,12 @@
+desc: "Test args parameter missing"
+min_ver: "0.20"
+
+components:
+  test:
+    builder:
+      type: custom_script
+      script: "../../resources/script.sh"
+      args: "-string"
+      target_images:
+        - "Image"
+

--- a/tests/integration_tests/custom_script_builder/test_args_is_string/test_args_is_string.py
+++ b/tests/integration_tests/custom_script_builder/test_args_is_string/test_args_is_string.py
@@ -1,0 +1,32 @@
+import subprocess
+import pytest
+import os
+import tempfile
+
+
+@pytest.mark.integration
+def test_args_is_string():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/test_args_is_string.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is not equal to '0'")
+
+        result = subprocess.run(["ninja"],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is not equal to '0'")
+        assert "string" not in result.stderr, "The expected arguments are missing"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/integration_tests/custom_script_builder/test_args_missing/resources/test_args_missing.yaml
+++ b/tests/integration_tests/custom_script_builder/test_args_missing/resources/test_args_missing.yaml
@@ -1,0 +1,11 @@
+desc: "Test args parameter missing"
+min_ver: "0.20"
+
+components:
+  test:
+    builder:
+      type: custom_script
+      script: "../../resources/script.sh"
+      target_images:
+        - "Image"
+

--- a/tests/integration_tests/custom_script_builder/test_args_missing/test_args_missing.py
+++ b/tests/integration_tests/custom_script_builder/test_args_missing/test_args_missing.py
@@ -1,0 +1,32 @@
+import subprocess
+import pytest
+import os
+import tempfile
+
+
+@pytest.mark.integration
+def test_args_missing():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/test_args_missing.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is not equal to '0'")
+
+        result = subprocess.run(["ninja"],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is not equal to '0'")
+        assert "No arguments" not in result.stderr, "The expected warning message is missing"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Moulin didn't work if 'args' parameter absent. Make that paremeter optional