### PR TITLE
Add support for Zephyr snippets

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -678,7 +678,10 @@ Optional parameters:
   kernel into :code:`additional_deps` of zephyr's config. This will
   ensure that zephyr will be built **after** DomU.
 
-* :code:`shields` - list of shields should be integrated to zephyr board.
+* :code:`shields` - list of shields should be integrated to zephyr board(For Zephyr < 3.4.0).
+
+* :code:`snippets` - list of snippets should be integrated to zephyr board(For Zephyr >= 3.4.0).
+  Please note that only one of :code:`shields` and :code:`snippets` can be used at the same time.
 
 * :code:`vars` - list of additional variables that should be passed to cmakw
   via :code:`west build`.

--- a/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_no_snippets.yaml
+++ b/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_no_snippets.yaml
@@ -1,0 +1,21 @@
+desc: "Integration test Zephyr snippets"
+min_ver: "0.22"
+
+
+components:
+  dom0:
+    default: true
+    build-dir: "ZEPHYR_BUILD_DIR"
+    sources:
+      - type: west
+        url: "https://github.com/xen-troops/aos_core_zephyr.git"
+        rev: "zephyr-v3.6.0"
+
+    builder:
+      type: zephyr
+      board: "rcar_spider"
+      target: aos_core_zephyr
+      work_dir: build
+
+      target_images:
+        - "build/zephyr/zephyr.bin"

--- a/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_one_snippet.yaml
+++ b/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_one_snippet.yaml
@@ -1,0 +1,28 @@
+desc: "Integration test Zephyr snippets"
+min_ver: "0.22"
+
+
+components:
+  dom0:
+    default: true
+    build-dir: "ZEPHYR_BUILD_DIR"
+    sources:
+      - type: west
+        url: "https://github.com/xen-troops/aos_core_zephyr.git"
+        rev: "zephyr-v3.6.0"
+
+    builder:
+      type: zephyr
+      board: "rcar_spider"
+      target: aos_core_zephyr
+      work_dir: build
+
+      snippets:
+        - "xen_dom0"
+
+      additional_deps:
+        - "dep_1"
+        - "dep_2"
+
+      target_images:
+        - "build/zephyr/zephyr.bin"

--- a/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_snippet_and_shield.yaml
+++ b/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_snippet_and_shield.yaml
@@ -1,0 +1,31 @@
+desc: "Integration test Zephyr snippets"
+min_ver: "0.22"
+
+
+components:
+  dom0:
+    default: true
+    build-dir: "ZEPHYR_BUILD_DIR"
+    sources:
+      - type: west
+        url: "https://github.com/xen-troops/aos_core_zephyr.git"
+        rev: "zephyr-v3.6.0"
+
+    builder:
+      type: zephyr
+      board: "rcar_spider"
+      target: aos_core_zephyr
+      work_dir: build
+
+      shields:
+        - "xen_dom0"
+
+      snippets:
+        - "xen_dom0"
+
+      additional_deps:
+        - "dep_1"
+        - "dep_2"
+
+      target_images:
+        - "build/zephyr/zephyr.bin"

--- a/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_two_snippets.yaml
+++ b/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/resources/zephyr_builder_with_two_snippets.yaml
@@ -1,0 +1,29 @@
+desc: "Integration test Zephyr snippets"
+min_ver: "0.22"
+
+
+components:
+  dom0:
+    default: true
+    build-dir: "ZEPHYR_BUILD_DIR"
+    sources:
+      - type: west
+        url: "https://github.com/xen-troops/aos_core_zephyr.git"
+        rev: "zephyr-v3.6.0"
+
+    builder:
+      type: zephyr
+      board: "rcar_spider"
+      target: aos_core_zephyr
+      work_dir: build
+
+      snippets:
+        - "xen_dom0"
+        - "xen_dom1"
+
+      additional_deps:
+        - "dep_1"
+        - "dep_2"
+
+      target_images:
+        - "build/zephyr/zephyr.bin"

--- a/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/test_zephyr_snippets_support.py
+++ b/tests/integration_tests/zephyr_builder/test_zephyr_snippets_support/test_zephyr_snippets_support.py
@@ -1,0 +1,93 @@
+import subprocess
+import pytest
+import os
+import tempfile
+import re
+
+
+@pytest.mark.integration
+def test_zephyr_one_snippet():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/zephyr_builder_with_one_snippet.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is equal to '0'")
+
+        with open(tmp_dir + "/build.ninja") as f:
+            ninja_file = f.read()
+            assert re.search(r"west build .*(\$\n)?.* \$snippets .*", ninja_file) is not None, \
+                   "Snippets paremeter present"
+            assert "snippets = -S xen_dom0" in ninja_file
+
+
+@pytest.mark.integration
+def test_zephyr_two_snippets():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/zephyr_builder_with_two_snippets.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is equal to '0'")
+
+        with open(tmp_dir + "/build.ninja") as f:
+            ninja_file = f.read()
+            assert re.search(r"west build .*(\$\n)?.* \$snippets .*", ninja_file) is not None, \
+                   "Snippets paremeter present"
+            assert "snippets = -S xen_dom0 -S xen_dom1" in ninja_file
+
+
+@pytest.mark.integration
+def test_zephyr_snippet_and_shield():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/zephyr_builder_with_snippet_and_shield.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode != 0, ("The return code is not equal to '0'")
+        assert "Both shields and snippets are specified, only one of them is allowed" in result.stderr, \
+               ("The expected error message")
+
+
+@pytest.mark.integration
+def test_zephyr_no_snippets():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/zephyr_builder_with_no_snippets.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is equal to '0'")
+
+        with open(tmp_dir + "/build.ninja") as f:
+            ninja_file = f.read()
+            print(ninja_file)
+            print(re.search(r"snippets = $", ninja_file, re.M))
+            assert re.search(r"snippets = $", ninja_file, re.M) is not None, "Snippets paremeter not present"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Zephyr 3.4.0 introduced a new feature called "snippets" which is a replacement for "shields". Add support for specifying snippets in Zephyr builder. Also, add a check to ensure that only one of "shields" or "snippets" is specified.