### PR TITLE
Improve the usage info

### DIFF
--- a/moulin/main.py
+++ b/moulin/main.py
@@ -100,7 +100,8 @@ def _handle_shared_opts(description: str,
             raise Exception(f"Config file requires version {conf.min_ver}," +
                             f" while you are running moulin {our_ver}")
 
-    prog = f"{sys.argv[0]} {local_conf_file}"
+    _, exec_name = os.path.split(sys.argv[0])
+    prog = f"{exec_name} {local_conf_file}"
     desc = f"Config file description: {conf.desc}"
     config_argparser = argparse.ArgumentParser(description=desc, prog=prog, add_help=False,
                                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/moulin/main.py
+++ b/moulin/main.py
@@ -102,7 +102,8 @@ def _handle_shared_opts(description: str,
 
     prog = f"{sys.argv[0]} {local_conf_file}"
     desc = f"Config file description: {conf.desc}"
-    config_argparser = argparse.ArgumentParser(description=desc, prog=prog, add_help=False)
+    config_argparser = argparse.ArgumentParser(description=desc, prog=prog, add_help=False,
+                                               formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     for parameter in conf.get_parameters().values():
         config_argparser.add_argument(f"--{parameter.name}",
                                       choices=[x.name for x in parameter.variants.values()],


### PR DESCRIPTION
- Display default values
- Remove path to the executable

---
Original output of the script
```
$ moulin --help-config prod-devel-rcar.yaml 
usage: /home/rsm/.local/bin/moulin prod-devel-rcar.yaml
                                                        [--MACHINE {salvator-xs-m3-2x4g,salvator-xs-h3-4x2g,salvator-x-h3-4x2g,h3ulcb-4x2g,h3ulcb-4x2g-kf,h3ulcb-4x2g-ab}]
                                                        [--ENABLE_ANDROID {no,yes}] [--ENABLE_DOMU {no,yes}] [--ENABLE_ZEPHYR {no,yes}] [--ENABLE_MM {no,yes}]
                                                        [--ENABLE_AOS_VIS {no,yes}] [--GRAPHICS {binaries,sources}]

Config file description: Xen-Troops development setup for Renesas RCAR Gen3 hardware

optional arguments:
  --MACHINE {salvator-xs-m3-2x4g,salvator-xs-h3-4x2g,salvator-x-h3-4x2g,h3ulcb-4x2g,h3ulcb-4x2g-kf,h3ulcb-4x2g-ab}
                        RCAR Gen3-based device
  --ENABLE_ANDROID {no,yes}
                        Build Android as a guest VM
  --ENABLE_DOMU {no,yes}
                        Build generic Yocto-based DomU
  --ENABLE_ZEPHYR {no,yes}
                        Build Zephyr as guest domain
  --ENABLE_MM {no,yes}  Enable Multimedia support
  --ENABLE_AOS_VIS {no,yes}
                        Enable AOS VIS service
  --GRAPHICS {binaries,sources}
                        Select how to use the GFX (3D hardware accelerator)
```

---

With this PR applied
```
$ /mnt/t1/projects/moulin/moulin.py --help-config prod-devel-rcar.yaml 
usage: moulin.py prod-devel-rcar.yaml [--MACHINE {salvator-xs-m3-2x4g,salvator-xs-h3-4x2g,salvator-x-h3-4x2g,h3ulcb-4x2g,h3ulcb-4x2g-kf,h3ulcb-4x2g-ab}]
                                      [--ENABLE_ANDROID {no,yes}] [--ENABLE_DOMU {no,yes}] [--ENABLE_ZEPHYR {no,yes}] [--ENABLE_MM {no,yes}]
                                      [--ENABLE_AOS_VIS {no,yes}] [--GRAPHICS {binaries,sources}]

Config file description: Xen-Troops development setup for Renesas RCAR Gen3 hardware

optional arguments:
  --MACHINE {salvator-xs-m3-2x4g,salvator-xs-h3-4x2g,salvator-x-h3-4x2g,h3ulcb-4x2g,h3ulcb-4x2g-kf,h3ulcb-4x2g-ab}
                        RCAR Gen3-based device (default: h3ulcb-4x2g)
  --ENABLE_ANDROID {no,yes}
                        Build Android as a guest VM (default: no)
  --ENABLE_DOMU {no,yes}
                        Build generic Yocto-based DomU (default: no)
  --ENABLE_ZEPHYR {no,yes}
                        Build Zephyr as guest domain (default: no)
  --ENABLE_MM {no,yes}  Enable Multimedia support (default: no)
  --ENABLE_AOS_VIS {no,yes}
                        Enable AOS VIS service (default: no)
  --GRAPHICS {binaries,sources}
                        Select how to use the GFX (3D hardware accelerator) (default: sources)

```