### PR TITLE
Fix issue with gpt-image

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2024, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.24'
+release = 'v0.25'
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.24',  # Required
+    version='0.25',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR fixes issue with new `gpt-image` v 0.9.0 package, that changed its API. This issue caused the error like this:

```
gpt_image.partition.PartitionEntryError: partition overflows the last allowed Logical Block Address: 2080736 requested: 4100097
```

To fix this, we need to read another property in `Partition` object. 

Second patch bumps the moulin version, as this is quite critical fix and we need to release it ASAP