### PR TITLE
rouge: Add support for resizing raw images

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2024, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.26'
+release = 'v0.27'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/rouge.rst
+++ b/docs/rouge.rst
@@ -218,6 +218,7 @@ partition (which is described below).
 
    type: raw_image # defines raw image block
    size: 400 MiB
+   resize: false
    image_path: "some/path/rootfs.ext4"
 
 :code:`image_path` is mandatory. This is a file to be included into
@@ -225,8 +226,13 @@ resulting image.
 
 :code:`size` is optional. If it is omitted, `rouge` will use size of
 file. If provided :code:`size` is smaller than file size, `rouge` will
-stop with an error. Thus, you can create block that is bigger than
-file, but not smaller.
+stop with an error. If provided :code:`size` is bigger than file size,
+`rouge` will try to resize the file to match :code:`size`.
+
+:code:`resize` is optional. If set to :code:`false`, it will prevent
+`rouge` from resizing the image to the size of the block. This is
+useful when you want to include a file that is smaller than the block
+and leave the rest of the block empty.
 
 Android Sparse Image Block
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/moulin/rouge/ext_utils.py
+++ b/moulin/rouge/ext_utils.py
@@ -93,3 +93,13 @@ def mmd(img: BinaryIO, folders: list):
     args.extend(folders)
 
     _run_cmd(args)
+
+
+def resize2fs(img: str, size: Optional[int] = None):
+    "Resize fs image to the given size"
+    args = ["resize2fs", img]
+
+    if size:
+        args.append(str(size))
+
+    _run_cmd(args)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.26',  # Required
+    version='0.27',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add new "resize" to the raw_image block, which allows rouge to resize the raw_image to the size set in the block.

This is useful when the image size needs to be changed frequently, or multiple images need to be created from the same source files, as it allows to skip the rootfs rebuild step.

Images are copied to a temporary directory before resizing to preserve the original build artifacts. The temporary directory is created in the current working directory to prevent filling the system's /tmp with large images.