### PR TITLE
logs: Add colored output

### DIFF
--- a/moulin/log_utils.py
+++ b/moulin/log_utils.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 EPAM Systems
+
+
+import logging
+import sys
+
+
+class ColoredFormatter(logging.Formatter):
+    # Define color codes
+    COLORS = {
+        'DEBUG': '\033[94m',      # Blue
+        'INFO': '\033[92m',       # Green
+        'WARNING': '\033[93m',    # Yellow
+        'ERROR': '\033[91m',      # Red
+        'CRITICAL': '\033[1;91m'  # Bold Red
+    }
+    RESET = '\033[0m'  # Reset color
+
+    def format(self, record):
+        log_color = self.COLORS.get(record.levelname, self.RESET)
+        message = super().format(record)
+
+        if sys.stderr.isatty():
+            return f"{log_color}{message}{self.RESET}"
+        else:
+            return message
+
+
+def build_handlers(log_format: str) -> list:
+    formatter = ColoredFormatter(log_format)
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    return [handler]

--- a/moulin/main.py
+++ b/moulin/main.py
@@ -23,6 +23,7 @@ from moulin import build_generator
 from moulin.build_conf import MoulinConfiguration
 import moulin.rouge
 import moulin.rouge.block_entry
+from moulin.log_utils import build_handlers
 
 log = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ def _handle_shared_opts(description: str,
     loglevel = logging.INFO
     if args.verbose:
         loglevel = logging.DEBUG
-    logging.basicConfig(level=loglevel, format="[%(levelname)s] %(message)s")
+    logging.basicConfig(level=loglevel, handlers=build_handlers("[%(levelname)s] %(message)s"))
 
     local_conf_file = _get_conf_file(args.conf)
 


### PR DESCRIPTION
Make the log output colored depending on the log level. This will make it much easier to quickly spot errors and warnings in the output, and also looks cooler.

Control characters for colors are only added if the output is a TTY, so the output can be redirected to a file without any issues.

Here are some examples:
![image](https://github.com/user-attachments/assets/a34ccfd2-0086-4516-82c7-b9684de00ad1)
![image](https://github.com/user-attachments/assets/bc390e7a-94ea-4f9c-816f-4c819169d007)

