### PR TITLE
Add option to create non-spared parts of images

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2024, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.27'
+release = 'v0.28'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/rouge.rst
+++ b/docs/rouge.rst
@@ -183,6 +183,28 @@ defines empty block with size of 4096 bytes. `rouge` supports some SI suffixes:
 Suffix must be separated from number by space. For example:
 :code:`size: 4 MiB` defines size of 4 mebibytes or 4 194 304 bytes.
 
+On `sparse` option
+^^^^^^^^^^^^^^^^^^
+
+Almost all block descriptions support boolean :code:`sparse` option,
+which is enabled by default. You can disable it to generate
+non-sparsed parts of a resulting images. This will create images that
+are bigger while stored on disk, because they physically store all
+non-needed NUL regions. But this may be used in cases when you need to
+zero-out some regions on a flash storage. Bear in mind, that in this
+case you can't write result image with
+
+.. code-block:: yaml
+
+    dd of=image.img of=/dev/outdevce conv=sparse
+
+because with :code:`conv=sparse` option :code:`dd` will "un-sparse"
+the image file, effectively skipping big zeroed regions. So, you
+either need to remove :code:`conv=sparse` option when calling
+:code:`dd`, increasing writing time significantly or use
+:code:`bmaptool` which should be less aggressive with sparsed regions
+detection.
+
 Empty block
 ^^^^^^^^^^^
 
@@ -234,6 +256,12 @@ stop with an error. If provided :code:`size` is bigger than file size,
 useful when you want to include a file that is smaller than the block
 and leave the rest of the block empty.
 
+:code:`sparse` is optional. If it set to to :code:`false`, raw image
+will be copied in non-sparse mode. This may increase final image
+size on disk and processing time. Use this option only when absolutely
+necessary, i.e when some piece of software (like bootloader) depends
+on values in un-allocated sectors.
+
 Android Sparse Image Block
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -255,6 +283,9 @@ size, read from the file. If provided :code:`size` is smaller than
 read size, `rouge` will stop with an error. Thus, you can create block
 that is bigger than unpacked file, but not smaller.
 
+:code:`sparse` is optional. If it set to to :code:`false`, Android
+sparsed image will be completely un-sparsed, up to creating a fully
+mapped file. It is seldom used, but it is added for completeness.
 
 Filesystem Image With Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -293,6 +324,12 @@ Also only :code:`items:` can contain directories.
 :code:`size` is optional. `rouge` will calculate total file size and
 add some space for the filesystem metadata to determine block size.
 You can increase size, if wish.
+
+:code:`sparse` is optional. If it set to to :code:`false`, filesystem
+image will be copied in non-sparse mode. This may increase final image
+size on disk and processing time. Use this option only when absolutely
+necessary, i.e when some piece of software (like bootloader) depends
+on values in un-allocated sectors.
 
 GUID Partition Table (GPT) block
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/moulin/rouge/block_entry.py
+++ b/moulin/rouge/block_entry.py
@@ -26,6 +26,9 @@ class BlockEntry():
     "Base class for various block entries"
 
     # pylint: disable=too-few-public-methods
+    def __init__(self, node: YamlValue, **kwargs):
+        self._node: YamlValue = node
+        self._size: int = 0
 
     def write(self, _file, _offset):
         "write() in base class does nothing"
@@ -50,8 +53,8 @@ class GPT(BlockEntry):
     "Represents GUID Partition Table"
 
     def __init__(self, node: YamlValue, **kwargs):
+        super().__init__(node, **kwargs)
         self._partitions: List[GPTPartition] = []
-        self._size: int = 0
         self._sector_size: int = 512
         self._requested_image_size: Optional[int] = None
 
@@ -127,9 +130,8 @@ class RawImage(BlockEntry):
     "Represents raw image file which needs to be copied as is"
 
     def __init__(self, node: YamlValue, **kwargs):
-        self._node = node
+        super().__init__(node, **kwargs)
         self._fname = self._node["image_path"].as_str
-        self._size = 0
         self._resize = True
 
     def _complete_init(self):
@@ -190,9 +192,8 @@ class AndroidSparse(BlockEntry):
     "Represents android sparse image file"
 
     def __init__(self, node: YamlValue, **kwargs):
-        self._node = node
+        super().__init__(node, **kwargs)
         self._fname = self._node["image_path"].as_str
-        self._size = 0
 
     def _read_size(self, mark: Mark):
         # pylint: disable=invalid-name
@@ -247,6 +248,7 @@ class EmptyEntry(BlockEntry):
     "Represents empty partition"
 
     def __init__(self, node: YamlValue, **kwargs):
+        super().__init__(node, **kwargs)
         self._size = _parse_size(node["size"])
         self._fill_by_zero = (node.get("filled", "").as_str == "zeroes")
 
@@ -263,8 +265,7 @@ class FileSystem(BlockEntry):
     "Represents a filesystem with list of files"
 
     def __init__(self, node: YamlValue, **kwargs):
-        self._node = node
-        self._size = 0
+        super().__init__(node, **kwargs)
         self._items: List[Tuple[str, str, Mark]] = []
 
         files_node = self._node.get("files", None)

--- a/moulin/rouge/ext_utils.py
+++ b/moulin/rouge/ext_utils.py
@@ -17,7 +17,11 @@ def _run_cmd(args):
 
 
 # pylint: disable=invalid-name
-def dd(file_in: Union[str, BinaryIO], file_out: BinaryIO, out_offset: int, out_size: Optional[int] = None):
+def dd(file_in: Union[str, BinaryIO],
+       file_out: BinaryIO,
+       out_offset: int,
+       out_size: Optional[int] = None,
+       sparse: bool = True):
     "Run dd with the given arguments"
     # Try to guess block size. We would like to use as big block as
     # possible. But we need take into account that "seek" parameter
@@ -37,9 +41,10 @@ def dd(file_in: Union[str, BinaryIO], file_out: BinaryIO, out_offset: int, out_s
         f"bs={blocksize}",
         f"seek={out_offset // blocksize}",
         "status=progress",
-        "conv=sparse",
         "conv=notrunc",
     ]  # yapf: disable
+    if sparse:
+        args.append("conv=sparse")
     if out_size:
         args.append(f"count={out_size // blocksize}")
     _run_cmd(args)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.27',  # Required
+    version='0.28',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This option is enabled by default for compatibility with previous
version. Also, this is sane value. But there are times, when `dd`
sparsed region detector behaves too greedy and emits un-allocated
regions even when in the original file those regions were populated
with zeroes. This is not a problem in day-to-day life, but can cause
issues when writing to un-initialized flash storages. To mitigate this
issue, `sparse` option is added to block description. This option
forces `dd` to generate un-sparsed regions, which may help in some
use-cases.