### PR TITLE
CI: switch GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub has discontinued support for ubuntu-20.04 runners on 2025-04-15. This commit updates the GitHub Actions workflow to use ubuntu-22.04 instead.