### PR TITLE
Add pytests for validation of missing "default: true" in parameters

### DIFF
--- a/tests/integration_tests/config_validator/test_check_default_true_negative/resources/test_check_default_true_negative.yaml
+++ b/tests/integration_tests/config_validator/test_check_default_true_negative/resources/test_check_default_true_negative.yaml
@@ -1,0 +1,17 @@
+desc: "Test check 'default: true' negative"
+min_ver: "0.26"
+
+
+components:
+  test:
+    builder:
+      type: "null"
+parameters:
+  paramA:
+    desc: "Parameter A"
+    variantA:
+      default: true
+  paramB:
+    desc: "Parameter B"
+    variantA:
+      # default: true

--- a/tests/integration_tests/config_validator/test_check_default_true_negative/test_check_default_true_negative.py
+++ b/tests/integration_tests/config_validator/test_check_default_true_negative/test_check_default_true_negative.py
@@ -1,0 +1,25 @@
+import subprocess
+import pytest
+import os
+import tempfile
+
+
+@pytest.mark.integration
+def test_check_default_true_negative():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/test_check_default_true_negative.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode != 0, ("The return code is equal to '0'")
+        assert "YAMLProcessingError" in result.stderr, ("Parameter has no default option")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/integration_tests/config_validator/test_check_default_true_positive/resources/test_check_default_true_positive.yaml
+++ b/tests/integration_tests/config_validator/test_check_default_true_positive/resources/test_check_default_true_positive.yaml
@@ -1,0 +1,17 @@
+desc: "Test check 'default: true' positive"
+min_ver: "0.26"
+
+
+components:
+  test:
+    builder:
+      type: "null"
+parameters:
+  paramA:
+    desc: "Parameter A"
+    variantA:
+      default: true
+  paramB:
+    desc: "Parameter B"
+    variantA:
+      default: true

--- a/tests/integration_tests/config_validator/test_check_default_true_positive/test_check_default_true_positive.py
+++ b/tests/integration_tests/config_validator/test_check_default_true_positive/test_check_default_true_positive.py
@@ -1,0 +1,24 @@
+import subprocess
+import pytest
+import os
+import tempfile
+
+
+@pytest.mark.integration
+def test_check_default_true_positive():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    yaml_file = os.path.join(script_dir_path, "resources/test_check_default_true_positive.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+
+        result = subprocess.run(["python", "../../../../../moulin.py", yaml_file],
+                                cwd=tmp_dir,
+                                stderr=subprocess.PIPE,
+                                text=True)
+
+        assert result.returncode == 0, ("The return code is equal to '0'")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unittest/test_config.py
+++ b/tests/unittest/test_config.py
@@ -123,8 +123,12 @@ desc: "Test build"
 parameters:
   paramA:
     desc: "Parameter A"
+    variantA:
+      default: true
   paramB:
     desc: "Parameter B"
+    variantA:
+      default: true
 """
         expected = ["paramA", "paramB"]
         conf = gen_config(doc)
@@ -138,7 +142,7 @@ parameters:
   paramA:
     desc: "Parameter A"
     variantA:
-      default: false
+      default: true
     variantB:
       default: false
     variantC:
@@ -173,9 +177,11 @@ parameters:
   paramA:
     desc: "Parameter A"
     variantA:
+      default: true
       overrides:
         val: A
     variantB:
+      default: false
       overrides:
         val: B
 """


### PR DESCRIPTION
Added pytests for the following scenarios:
-- YAML parameter does not contain a "default: true" variant (negative case)
-- YAML parameter contains a "default: true" variant (positive case)

Also, the unit test "test_config.py" was updated because "default: true" is required for all parameters in the YAML configuration.