### PR TITLE
Add utility builders yocto

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -63,7 +63,16 @@ files for Ninja, so Ninja can track changes inside components.
 :code:`dependency_policy` and writes the selected dependency set after a
 successful build command.
 
-This option is not meant to be used by a user.
+There is also a family of internal :code:`--utility-*` command-line
+options. These options are hidden from the :code:`-h` output and are
+used internally by `moulin` to invoke builder-specific utility
+handlers.
+
+For example, :code:`--utility-builders-yocto` is used by the Yocto
+builder to synchronize the active BitBake layer configuration with
+the layer list defined in the Moulin YAML manifest.
+
+These options are not meant to be used by a user.
 
 YAML sections
 -------------
@@ -472,8 +481,9 @@ yocto builder
 Yocto builder is used to build OpenEmbedded-based images. It expects
 that `poky` repository is cloned in :code:`{build_dir}/poky` and uses
 it's :code:`poky/oe-init-build-env` script to initialize build
-environment. Then :code:`bitbake-layers` tool is used to add
-additional layers and :code:`bitbake` used to perform the build.
+environment. Then Moulin synchronizes the active BitBake layer
+configuration with the layer list defined in the YAML file, and
+:code:`bitbake` is used to perform the build.
 
 .. code-block:: yaml
 
@@ -527,9 +537,12 @@ needed if you are building multiple VMs with cross-dependencies.
   :code:`local.conf`. Instead, a new file :code:`moulin.conf` will be
   created. This file will then be included from :code:`local.conf`.
 
-* :code:`layers` - list of additional layers. Those layers will be
-  added to the build using :code:`bitbake-layers add-layer {layers}`
-  command.
+* :code:`layers` - list of layers managed by Moulin for this Yocto
+  build. Moulin synchronizes the active BitBake layer configuration
+  with this list: it adds missing layers, removes layers that were
+  previously managed by Moulin but are no longer listed, and reorders
+  managed layers when needed. Layers not managed by Moulin are left
+  untouched.
 
 * :code:`work_dir` - `bitbake`'s work directory. The default value is
   "build". This is where files like "conf/local.conf" are stored. You

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -12,6 +12,12 @@ from moulin import ninja_syntax
 from moulin.yaml_wrapper import YamlValue
 from moulin.yaml_helpers import YAMLProcessingError
 import logging
+import sys
+import subprocess
+import argparse
+import os
+import re
+from pathlib import Path
 
 
 YOCTO_CORE_LAYERS = ["../poky/meta", "../poky/meta-poky", "../poky/meta-yocto-bsp"]
@@ -41,16 +47,21 @@ def gen_build_rules(generator: ninja_syntax.Writer):
                    restat=True)
     generator.newline()
 
-    # Add bitbake layers by calling bitbake-layers script
-    cmd = " && ".join([
-        "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
-        "bitbake-layers add-layer $layers",
-        "touch $out",
-    ])
-    generator.rule("yocto_add_layers",
+    # Minimal CLI: program + --utility-builders-yocto + all args.
+    prog = os.path.basename(sys.argv[0])
+
+    # Add and remove bitbake layers use --utility-builders-yocto
+    cmd = (
+        f"{prog} "
+        "--utility-builders-yocto "
+        "--yocto-dir $yocto_dir "
+        "--work-dir $work_dir "
+        "--layers $layers "
+        "--stamp $out"
+    )
+    generator.rule("yocto_update_layers",
                    command=f'bash -c "{cmd}"',
-                   description="Add yocto layers",
+                   description="Add and remove yocto layers",
                    pool="console",
                    restat=True)
     generator.newline()
@@ -235,7 +246,7 @@ class YoctoBuilder:
             layers_stamp = create_stamp_name(self.yocto_dir, self.work_dir, "yocto", "layers")
             layers = " ".join(_filter_yocto_core_layers(_flatten_layers(layers_node)))
             self.generator.build(layers_stamp,
-                                 "yocto_add_layers",
+                                 "yocto_update_layers",
                                  env_target,
                                  variables=dict(common_variables, layers=layers))
 
@@ -287,3 +298,135 @@ class YoctoBuilder:
         Update stored local conf with actual SRCREVs for VCS-based recipes.
         This should ensure that we can reproduce this exact build later
         """
+
+
+def _env_prefix(yocto_dir: str, work_dir: str) -> str:
+    """
+    Return a shell snippet that cd's into yocto_dir and sources
+    oe-init-build-env for work_dir.
+    """
+    return " && ".join([
+        f"cd {yocto_dir}",
+        f". poky/oe-init-build-env {work_dir}",
+    ])
+
+
+def _run_bash(cmd: str, *, capture=False) -> subprocess.CompletedProcess:
+    """Run a bash -lc command."""
+    return subprocess.run(
+        ["bash", "-lc", cmd],
+        check=True,
+        capture_output=capture,
+        text=capture,
+    )
+
+
+def rels_to_abs(base: Path, rels: List[str]) -> List[str]:
+    return [str((base / rel).resolve(strict=False)) for rel in rels]
+
+
+def handle_utility_call(argv: List[str]) -> int:
+    """
+    Synchronize Yocto build layers with the specification from YAML.
+    The function ensures that the active Yocto layers in a build directory
+    match the layers defined in the YAML configuration. It uses a "stamp"
+    file to detect if synchronization has already been performed.
+
+    Workflow:
+
+      1. If the stamp file does not exist:
+         - Add all specified YAML layers to the build environment.
+         - Create the stamp file.
+
+      2. If the stamp file exists:
+         - Run 'bitbake-layers show-layers' to read the currently active layers.
+         - Normalize their paths and exclude Yocto core layers.
+         - Compare "layers from argv (YAML)" vs "currently active layers."
+         - If the sets differ -> remove extra layers and add missing ones.
+    """
+
+    # Parse args
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--yocto-dir", required=True)  # path to yocto root
+    parser.add_argument("--work-dir", required=True)  # path to build dir
+    parser.add_argument("--layers", nargs="+", required=True)  # YAML layers (relative to yocto root)
+    parser.add_argument("--stamp", required=True)  # stamp file path
+    args = parser.parse_args(argv)
+
+    # Extract args into local variables
+    yaml_layers_str = " ".join(args.layers)
+    yocto_root = args.yocto_dir
+    build_dir = args.work_dir
+    stamp_out = args.stamp
+    stamp_exists = Path(stamp_out).exists()
+    env_prefix = _env_prefix(yocto_root, build_dir)
+
+    # Compute absolute build path
+    build_dir_path = Path(build_dir)
+    build_dir_abs: Path = (
+        build_dir_path if build_dir_path.is_absolute()
+        else (Path(yocto_root) / build_dir_path)).resolve(strict=False)
+
+    # CASE 1: No stamp file yet -> add layers and create stamp
+    if not stamp_exists:
+        _run_bash(" && ".join([
+            f"{env_prefix}",
+            f"bitbake-layers add-layer {yaml_layers_str}",
+            f"touch {stamp_out}",
+        ]))
+        return 0
+
+    # CASE 2: Stamp exists -> check current state and sync if neededs
+    # Run "bitbake-layers show-layers" to list currently active layers
+    # Out of command for examle:
+    #     layer                 path                             priority
+    # ==========================================================================
+    # meta                  /home/../../project/yocto/poky/meta  5
+    # meta-poky             /home/../../project/yocto/poky/meta-poky  5
+    # meta-yocto-bsp        /home/../../project/yocto/poky/meta-yocto-bsp  5
+    # meta-virtualization   /home/../../project/yocto/meta-virtualization  8
+    # meta-oe               /home/../../project/yocto/meta-openembedded/meta-oe  5
+    # meta-filesystems      /home/../../project/yocto/meta-openembedded/meta-filesystems  5
+    # meta-python           /home/../../project/yocto/meta-openembedded/meta-python  5
+    # meta-networking       /home/../../project/yocto/meta-openembedded/meta-networking  5
+    # ...and so on
+    show_output = _run_bash(f"{env_prefix} && bitbake-layers show-layers", capture=True).stdout
+
+    # Extract the 'path' column with regex
+    row_re = re.compile(r"^[ \t]*#?[ \t]*\S+[ \t]+(?P<path>.+?)[ \t]+(?:\d+)[ \t]*$", re.MULTILINE)
+    show_output_paths_only: List[str] = row_re.findall(show_output)
+
+    # Canonicalize build layers path
+    canonical_show_path = [str(Path(p).expanduser().resolve(strict=False)) for p in show_output_paths_only]
+
+    # Get absolute paths for Yocto Core Layers lay
+    yocto_core_layers_abs: List[str] = rels_to_abs(build_dir_abs, YOCTO_CORE_LAYERS)
+
+    # Get absolute paths for YAML-specified layers
+    yaml_layers_abs: List[str] = rels_to_abs(build_dir_abs, args.layers)
+
+    # Filter out core layers to get only build-managed layers
+    used_build_layers_abs = set(canonical_show_path) - set(yocto_core_layers_abs)
+
+    # Determine which layers should be removed
+    to_remove_abs = set(used_build_layers_abs) - set(yaml_layers_abs)
+    # Determine which layers should be added
+    to_add_abs = set(yaml_layers_abs) - set(used_build_layers_abs)
+
+    # If there are layers to remove, otherwise empty string
+    remove_cmd = ("bitbake-layers remove-layer " + " ".join(to_remove_abs)
+                  if to_remove_abs else "")
+
+    # If there are layers to add, otherwise empty string
+    add_cmd = ("bitbake-layers add-layer " + " ".join(to_add_abs)
+               if to_add_abs else "")
+
+    # Always update the stamp file at the end
+    touch_cmd = f"touch {stamp_out}"
+
+    # Collect all command parts, skip empty ones, join with &&
+    cmd_parts = [env_prefix, remove_cmd, add_cmd, touch_cmd]
+    cmd = " && ".join(part for part in cmd_parts if part)
+
+    _run_bash(cmd)
+    return 0

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -12,6 +12,12 @@ from moulin import ninja_syntax
 from moulin.yaml_wrapper import YamlValue
 from moulin.yaml_helpers import YAMLProcessingError
 import logging
+import sys
+import subprocess
+import argparse
+import os
+import re
+from pathlib import Path
 
 
 YOCTO_CORE_LAYERS = ["../poky/meta", "../poky/meta-poky", "../poky/meta-yocto-bsp", "../openembedded-core/meta"]
@@ -41,16 +47,21 @@ def gen_build_rules(generator: ninja_syntax.Writer):
                    restat=True)
     generator.newline()
 
-    # Add bitbake layers by calling bitbake-layers script
-    cmd = " && ".join([
-        "cd $yocto_dir",
-        "source $distro_dir/oe-init-build-env $work_dir",
-        "bitbake-layers add-layer $layers",
-        "touch $out",
-    ])
-    generator.rule("yocto_add_layers",
+    # Minimal CLI: program + --utility-builders-yocto + all args.
+    prog = os.path.basename(sys.argv[0])
+
+    # Use --utility-builders-yocto to add and remove BitBake layers
+    cmd = (
+        f"{prog} "
+        "--utility-builders-yocto "
+        "--yocto-dir $yocto_dir "
+        "--work-dir $work_dir "
+        "--layers $layers "
+        "--stamp $out"
+    )
+    generator.rule("yocto_update_layers",
                    command=f'bash -c "{cmd}"',
-                   description="Add yocto layers",
+                   description="Synchronize Yocto layers with a moulin configuration file",
                    pool="console",
                    restat=True)
     generator.newline()
@@ -240,9 +251,12 @@ class YoctoBuilder:
         layers_node = self.conf.get("layers", None)
         if layers_node:
             layers_stamp = create_stamp_name(self.yocto_dir, self.work_dir, "yocto", "layers")
-            layers = " ".join(_filter_yocto_core_layers(_flatten_layers(layers_node)))
+            layers = " ".join(
+                shlex.quote(layer)
+                for layer in _filter_yocto_core_layers(_flatten_layers(layers_node))
+            )
             self.generator.build(layers_stamp,
-                                 "yocto_add_layers",
+                                 "yocto_update_layers",
                                  env_target,
                                  variables=dict(common_variables, layers=layers))
 
@@ -294,3 +308,215 @@ class YoctoBuilder:
         Update stored local conf with actual SRCREVs for VCS-based recipes.
         This should ensure that we can reproduce this exact build later
         """
+
+
+def _env_prefix(yocto_dir: str, work_dir: str) -> str:
+    """
+    Return a shell snippet that cd's into yocto_dir and sources
+    oe-init-build-env for work_dir.
+    """
+    return " && ".join([
+        f"cd {shlex.quote(yocto_dir)}",
+        f". poky/oe-init-build-env {shlex.quote(work_dir)}",
+    ])
+
+
+def _run_bash(cmd: str, *, capture=False) -> subprocess.CompletedProcess:
+    """Run a bash -lc command."""
+    return subprocess.run(
+        ["bash", "-lc", cmd],
+        check=True,
+        capture_output=capture,
+        text=capture,
+    )
+
+
+def relative_paths_to_absolute(base: Path, rels: List[str]) -> List[str]:
+    return [str((base / rel).resolve(strict=False)) for rel in rels]
+
+
+def _read_managed_layers(stamp: str) -> List[str]:
+    path = Path(stamp)
+    if not path.exists():
+        return []
+    return [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def _write_managed_layers(stamp: str, layers: List[str]) -> None:
+    Path(stamp).write_text("\n".join(layers) + "\n")
+
+
+def _parse_layers_output(output: str) -> List[str]:
+    """
+    Parse the output of 'bitbake-layers show-layers' and return
+    canonical absolute layer paths.
+
+    Example command output:
+
+        layer                 path                             priority
+        ==============================================================
+        meta                  /home/.../yocto/poky/meta        5
+        meta-poky             /home/.../yocto/poky/meta-poky   5
+        meta-yocto-bsp        /home/.../yocto/poky/meta-yocto-bsp  5
+        meta-virtualization   /home/.../yocto/meta-virtualization  8
+        meta-oe               /home/.../meta-openembedded/meta-oe  5
+        ...
+    """
+
+    # Extract the 'path' column with regex
+    row_re = re.compile(
+        r"^[ \t]*#?[ \t]*\S+[ \t]+(?P<path>.+?)[ \t]+(?:\d+)[ \t]*$",
+        re.MULTILINE,
+    )
+    layer_paths = row_re.findall(output)
+
+    # Canonicalize build layer paths
+    return [
+        str(Path(p).expanduser().resolve(strict=False))
+        for p in layer_paths
+    ]
+
+
+def _compute_layer_sync(current_layers: List[str], previous_managed_layers: List[str],
+                        yaml_layers: List[str]) -> Tuple[List[str], List[str]]:
+    """
+    Compute the set of managed layers that should be removed and added
+    to synchronize the current build with the YAML specification.
+    """
+    # Create sets for efficient lookup during synchronization
+    current_layer_paths_set = set(current_layers)
+    yaml_layers_set = set(yaml_layers)
+    previous_managed_layers_set = set(previous_managed_layers)
+
+    # Consider only layers that are managed by Moulin.
+    # External layers reported by bitbake-layers are ignored.
+    # Preserve the current relative order of managed layers.
+    current_managed_layers = [
+        p for p in current_layers
+        if p in previous_managed_layers_set or p in yaml_layers_set
+    ]
+
+    # Remove only layers that Moulin managed before and that disappeared from YAML.
+    to_remove = [
+        p for p in previous_managed_layers
+        if p not in yaml_layers_set and p in current_layer_paths_set
+    ]
+
+    # Add YAML layers that are missing from the current build.
+    to_add = [
+        p for p in yaml_layers
+        if p not in current_layer_paths_set
+    ]
+
+    # Check whether simple remove + append-add preserves YAML order.
+    expected_after_diff = [
+        p for p in current_managed_layers
+        if p in yaml_layers_set
+    ] + to_add
+
+    if expected_after_diff != yaml_layers:
+        # Recreate only Moulin-managed layers in the YAML order.
+        to_remove = [
+            p for p in current_managed_layers
+            if p in current_layer_paths_set
+        ]
+        to_add = yaml_layers
+
+    return to_remove, to_add
+
+
+def handle_utility_call(argv: List[str]) -> int:
+    """
+    Synchronize Yocto build layers with the specification from YAML.
+
+    Moulin manages only layers explicitly defined in YAML or previously
+    recorded in the stamp/state file. Layers added externally are ignored.
+
+    Workflow:
+
+      1. If the stamp/state file does not exist:
+        - Add all specified YAML layers to the build environment.
+        - Store the list of managed layers in the stamp/state file.
+
+      2. If the stamp/state file exists:
+        - Run 'bitbake-layers show-layers' to read all active layers.
+        - Normalize layer paths.
+        - Consider only Moulin-managed layers.
+        - Remove layers that were previously managed but disappeared from YAML.
+        - Add YAML layers missing from the current build.
+        - Recreate managed layers if needed to preserve YAML order.
+        - Update the stamp/state file.
+    """
+
+    # Parse args
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--yocto-dir", required=True)  # path to Yocto root
+    parser.add_argument("--work-dir", required=True)  # path to build dir
+    parser.add_argument("--layers", nargs="+", required=True)  # YAML layers (relative to yocto root)
+    parser.add_argument("--stamp", required=True)  # stamp file path
+    args = parser.parse_args(argv)
+
+    # Extract args into local variables
+    yaml_layers_str = " ".join(
+        shlex.quote(layer)
+        for layer in args.layers
+    )
+    yocto_root = args.yocto_dir
+    build_dir = args.work_dir
+    stamp_out = args.stamp
+    stamp_exists = Path(stamp_out).exists()
+    env_prefix = _env_prefix(yocto_root, build_dir)
+
+    # Compute absolute build path
+    build_dir_path = Path(build_dir)
+    build_dir_abs: Path = (
+        build_dir_path if build_dir_path.is_absolute()
+        else (Path(yocto_root) / build_dir_path)).resolve(strict=False)
+
+    # Get absolute paths for YAML-specified layers
+    yaml_layers_abs: List[str] = relative_paths_to_absolute(build_dir_abs, args.layers)
+
+    # CASE 1: No stamp/state file yet -> add YAML layers and record them as managed by Moulin
+    if not stamp_exists:
+        _run_bash(" && ".join([
+            f"{env_prefix}",
+            f"bitbake-layers add-layer {yaml_layers_str}",
+        ]))
+        _write_managed_layers(stamp_out, yaml_layers_abs)
+        return 0
+
+    # CASE 2: State file exists -> sync only Moulin-managed layers
+    # Run "bitbake-layers show-layers" to list currently active layers
+    layers_output = _run_bash(f"{env_prefix} && bitbake-layers show-layers", capture=True).stdout
+
+    current_layers = _parse_layers_output(layers_output)
+    previous_managed_layers = _read_managed_layers(stamp_out)
+
+    to_remove_abs, to_add_abs = _compute_layer_sync(
+        current_layers,
+        previous_managed_layers,
+        yaml_layers_abs,
+    )
+
+    remove_cmd = (
+        "bitbake-layers remove-layer " +
+        " ".join(shlex.quote(p) for p in to_remove_abs)
+        if to_remove_abs else ""
+    )
+
+    add_cmd = (
+        "bitbake-layers add-layer " +
+        " ".join(shlex.quote(p) for p in to_add_abs)
+        if to_add_abs else ""
+    )
+
+    cmd_parts = [env_prefix, remove_cmd, add_cmd]
+    cmd = " && ".join(part for part in cmd_parts if part)
+
+    _run_bash(cmd)
+    _write_managed_layers(stamp_out, yaml_layers_abs)
+    return 0

--- a/moulin/main.py
+++ b/moulin/main.py
@@ -34,6 +34,7 @@ OptionDef = Tuple[List[str], Dict[str, Any]]
 # Marker prefix for utility calls
 UTILITY_PREFIX = "--utility-"
 
+
 def _dispatch_utility(mod_qual: str, argv: List[str]) -> int:
     """
     Import moulin.<mod_qual>, find handle_utility_call() and run it.

--- a/moulin/main.py
+++ b/moulin/main.py
@@ -11,6 +11,7 @@ from time import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
+import importlib
 import importlib_metadata
 import yaml
 from urllib.parse import urlparse, unquote
@@ -30,10 +31,31 @@ log = logging.getLogger(__name__)
 
 OptionDef = Tuple[List[str], Dict[str, Any]]
 
+# Marker prefix for utility calls
+UTILITY_PREFIX = "--utility-"
 
-def _prepre_shared_opts(description: str,
-                        additional_opts: Optional[List[OptionDef]] = None,
-                        exclusive_opts: Optional[List[List[OptionDef]]] = None):
+def _dispatch_utility(mod_qual: str, argv: List[str]) -> int:
+    """
+    Import moulin.<mod_qual>, find handle_utility_call() and run it.
+    Utilities do NOT receive a configuration object.
+    """
+    try:
+        mod = importlib.import_module(f"moulin.{mod_qual}")
+    except ModuleNotFoundError as e:
+        log.error("Utility module 'moulin.%s' not found: %s", mod_qual, e)
+        sys.exit(2)
+
+    handler = getattr(mod, "handle_utility_call", None)
+    if handler is None:
+        log.error("Utility 'moulin.%s' has no handle_utility_call()", mod_qual)
+        sys.exit(2)
+
+    return handler(argv)
+
+
+def _prepare_shared_opts(description: str,
+                         additional_opts: Optional[List[OptionDef]] = None,
+                         exclusive_opts: Optional[List[List[OptionDef]]] = None):
 
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('conf',
@@ -83,7 +105,7 @@ def _handle_shared_opts(description: str,
                         additional_opts: Optional[List[OptionDef]] = None,
                         exclusive_opts: Optional[List[List[OptionDef]]] = None):
 
-    parser = _prepre_shared_opts(description, additional_opts, exclusive_opts)
+    parser = _prepare_shared_opts(description, additional_opts, exclusive_opts)
 
     args, extra_opts = parser.parse_known_args()
 
@@ -135,9 +157,53 @@ def moulin_entry():
             (["--dep"], dict(nargs=1, metavar="component", help=argparse.SUPPRESS)),
         ],
     ]
-    conf, args = _handle_shared_opts(
-        f'Moulin meta-build system v{Version(importlib_metadata.version("moulin"))}',
-        exclusive_opts=exclusive_opts)
+
+    desc = f'Moulin meta-build system v{Version(importlib_metadata.version("moulin"))}'
+
+    # Read raw argv without the program name.
+    # Intentionally avoid argparse here because the "normal" parser expects
+    # a positional build.yaml, which is not used in utility mode.
+    argv = sys.argv[1:]
+
+    # Utility detection state:
+    util_name = None  # utility identifier after the prefix (e.g. "builders-yocto")
+    util_pos = None  # index of the utility token in argv
+    util_argv = []  # tail arguments after the utility token (to pass into the handler)
+
+    # Search argv for the utility prefix ("--utility-").
+    # Once found, capture its name, position, and the trailing arguments.
+    for i, tok in enumerate(argv):
+        if tok.startswith(UTILITY_PREFIX):
+            util_name = tok[len(UTILITY_PREFIX):]
+            util_pos = i
+            util_argv = argv[i+1:]
+            break
+
+    # If the --utility argument is present
+    if util_name is not None:
+        # In utility mode we never accept a configuration file. Therefore, any token
+        # that appears before the utility token and does NOT start with '-' is treated
+        # as a positional argument (most commonly a build.yaml path) and must be rejected.
+        pre_tokens = argv[:util_pos] if util_pos is not None else []
+        offending = []
+        for t in pre_tokens:
+            if not t.startswith("-"):
+                offending.append(t)
+
+        if offending:
+            log.error(
+                "Utility mode does not accept a configuration file. "
+                "Remove build.yaml when using '--utility-*'. Offending token(s): %s",
+                " ".join(offending),
+            )
+            sys.exit(2)
+
+        # Dispatch the utility WITHOUT a configuration object.
+        mod_qual = util_name.replace("-", ".")
+        return _dispatch_utility(mod_qual, util_argv)
+
+    # If the --utility parameter is not specified --> normal execution flow
+    conf, args = _handle_shared_opts(desc, exclusive_opts=exclusive_opts)
 
     if args.fetcherdep:
         log.error("build.ninja was created with an older version of Moulin. "

--- a/moulin/main.py
+++ b/moulin/main.py
@@ -11,6 +11,7 @@ from time import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Tuple, Any
+import importlib
 import importlib_metadata
 import yaml
 from urllib.parse import urlparse, unquote
@@ -29,6 +30,28 @@ from moulin.log_utils import build_handlers
 log = logging.getLogger(__name__)
 
 OptionDef = Tuple[List[str], Dict[str, Any]]
+
+# Marker prefix for utility calls
+UTILITY_PREFIX = "--utility-"
+
+
+def _dispatch_utility(mod_qual: str, argv: List[str]) -> int:
+    """
+    Import moulin.<mod_qual>, find handle_utility_call() and run it.
+    Utilities do NOT receive a configuration object.
+    """
+    try:
+        mod = importlib.import_module(f"moulin.{mod_qual}")
+    except ModuleNotFoundError as e:
+        log.error("Utility module 'moulin.%s' not found: %s", mod_qual, e)
+        sys.exit(2)
+
+    handler = getattr(mod, "handle_utility_call", None)
+    if handler is None:
+        log.error("Utility 'moulin.%s' has no handle_utility_call()", mod_qual)
+        sys.exit(2)
+
+    return handler(argv)
 
 
 def _prepre_shared_opts(description: str,
@@ -132,9 +155,52 @@ def moulin_entry():
     additional_opts = [
         (["--fetcherdep"], dict(nargs=1, metavar="component", help=argparse.SUPPRESS)),
     ]
-    conf, args = _handle_shared_opts(
-        f'Moulin meta-build system v{Version(importlib_metadata.version("moulin"))}',
-        additional_opts=additional_opts)
+    desc = f'Moulin meta-build system v{Version(importlib_metadata.version("moulin"))}'
+
+    # Read raw argv without the program name.
+    # Intentionally avoid argparse here because the "normal" parser expects
+    # a positional build.yaml, which is not used in utility mode.
+    argv = sys.argv[1:]
+
+    # Utility detection state:
+    util_name = None  # utility identifier after the prefix (e.g. "builders-yocto")
+    util_pos = None  # index of the utility token in argv
+    util_argv = []  # tail arguments after the utility token (to pass into the handler)
+
+    # Find in argv for the utility prefix ("--utility-").
+    # Once found, capture its name, position, and the trailing arguments.
+    for i, tok in enumerate(argv):
+        if tok.startswith(UTILITY_PREFIX):
+            util_name = tok[len(UTILITY_PREFIX):]
+            util_pos = i
+            util_argv = argv[i+1:]
+            break
+
+    # If the --utility argument is present
+    if util_name is not None:
+        # In utility mode we never accept a configuration file. Therefore, any token
+        # that appears before the utility token and does NOT start with '-' is treated
+        # as a positional argument (most commonly a build.yaml path) and must be rejected.
+        pre_tokens = argv[:util_pos] if util_pos is not None else []
+        offending = []
+        for t in pre_tokens:
+            if not t.startswith("-"):
+                offending.append(t)
+
+        if offending:
+            log.error(
+                "Utility mode does not accept a configuration file. "
+                "Remove build.yaml when using '--utility-*'. Offending token(s): %s",
+                " ".join(offending),
+            )
+            sys.exit(2)
+
+        # Dispatch the utility WITHOUT a configuration object.
+        mod_qual = util_name.replace("-", ".")
+        return _dispatch_utility(mod_qual, util_argv)
+
+    # If the --utility parameter is not specified --> normal execution flow
+    conf, args = _handle_shared_opts(desc, additional_opts)
 
     if not args.fetcherdep:
         # Check version and notify

--- a/tests/unittest/test_utility_builders_yocto_sync_layers.py
+++ b/tests/unittest/test_utility_builders_yocto_sync_layers.py
@@ -1,0 +1,629 @@
+import unittest
+import shlex
+from unittest.mock import patch, Mock
+import moulin.builders.yocto as yocto_mod
+from pathlib import Path
+
+
+class TestYoctoUtilitySyncLayers(unittest.TestCase):
+    def test_first_run_no_stamp_calls_add_layer(self):
+        """
+        First run (stamp file does not exist):
+        - correct list of layers is passed to "bitbake-layers add-layer"
+        - managed layer list is written to the stamp/state file
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # stamp file does not exist -> return_value=False
+        with patch("moulin.builders.yocto.Path.exists", return_value=False), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # cmd contains bitbake-layers add-layer and all layers
+        self.assertIn("bitbake-layers add-layer", cmd)
+        for layer in layers:
+            self.assertIn(shlex.quote(layer), cmd)
+
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_adds_and_removes_layers(self):
+        """
+        Stamp exists and layer set differs:
+        - obsolete layer is removed
+        - missing layers are added
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # -> this one is *not* in layers and must be removed
+        unneeded_rel = "../current-fake-layer"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+        unneeded_abs = str((build_abs / unneeded_rel).resolve(strict=False))
+
+        # show-layers output contains external layers and one obsolete managed layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"meta   {unneeded_abs} 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._read_managed_layers",
+                   return_value=[unneeded_abs]) as mock_read, \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> remove obsolete and add missing layers
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # check remove-layer segment
+        self.assertIn("bitbake-layers remove-layer", cmd)
+        rm_seg = cmd.split("bitbake-layers remove-layer", 1)[1].split(" && ", 1)[0]
+        # unneeded_abs must be present in remove
+        self.assertIn(shlex.quote(unneeded_abs), rm_seg, msg=f"{unneeded_abs} \
+            not found in remove-layer segment:\n{rm_seg}")
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # all layers_abs must be in add-layer
+        for p in layers_abs:
+            self.assertIn(shlex.quote(p), add_seg, msg=f"{p} \
+            not found in add-layer segment:\n{add_seg}")
+        # there shouldn't be unneeded_abs there
+        self.assertNotIn(shlex.quote(unneeded_abs), add_seg, msg=f"{unneeded_abs} \
+            must NOT be in add-layer segment:\n{add_seg}")
+
+        # managed layer state was updated
+        mock_read.assert_called_once_with(stamp_path)
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_only_external_layers_adds_yaml_layers(self):
+        """
+        Stamp exists, but only external layers are present:
+        - no layers are removed
+        - YAML layers are added
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+
+        # show-layers output contains only externally managed layers
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers", return_value=[]), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> apply diff
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # no remove-layer command is needed
+        self.assertNotIn("bitbake-layers remove-layer", cmd)
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # all layers_abs must be in add-layer
+        for p in layers_abs:
+            self.assertIn(
+                shlex.quote(p),
+                add_seg,
+                msg=f"{p} not found in add-layer segment:\n{add_seg}",
+            )
+
+        # managed layer state was updated
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_identical_layers_no_add_or_remove(self):
+        """
+        Stamp exists and layers already match YAML:
+        - no layers are removed
+        - no layers are added
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+
+        # show-layers output contains managed layers including one obsolete layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"fake1  {layers_abs[0]} 5\n"
+            f"fake2  {layers_abs[1]} 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers", return_value=layers_abs), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> no layer changes required
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # no add/remove commands are needed
+        self.assertNotIn("bitbake-layers remove-layer", cmd)
+        self.assertNotIn("bitbake-layers add-layer", cmd)
+
+        # managed layer state was updated
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_reorders_layers_to_match_yaml_order(self):
+        """
+        Stamp exists and layers are the same, but order differs:
+        - managed layers are removed in the current order
+        - managed layers are added back in YAML order
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+
+        # show-layers output contains managed layers in reverse order
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"fake2  {layers_abs[1]} 5\n"
+            f"fake1  {layers_abs[0]} 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers", return_value=layers_abs), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> reorder layers
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # check remove-layer segment
+        self.assertIn("bitbake-layers remove-layer", cmd)
+        rm_seg = cmd.split("bitbake-layers remove-layer", 1)[1].split(" && ", 1)[0]
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # remove order must follow the current show-layers order
+        self.assertLess(
+            rm_seg.index(shlex.quote(layers_abs[1])),
+            rm_seg.index(shlex.quote(layers_abs[0])),
+        )
+
+        # add order must follow the YAML order
+        self.assertLess(
+            add_seg.index(shlex.quote(layers_abs[0])),
+            add_seg.index(shlex.quote(layers_abs[1])),
+        )
+
+        # managed layer state was updated
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_only_removes_obsolete_layer(self):
+        """
+        Stamp exists and YAML has fewer layers:
+        - obsolete layer is removed
+        - no layers are added
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+        obsolete_abs = str((build_abs / "../obsolete-layer").resolve(strict=False))
+
+        # show-layers output contains only the first managed layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"fake1  {layers_abs[0]} 5\n"
+            f"obsolete  {obsolete_abs} 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers",
+             return_value=[layers_abs[0], obsolete_abs]), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> remove obsolete layer
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # check remove-layer segment
+        self.assertIn("bitbake-layers remove-layer", cmd)
+        rm_seg = cmd.split("bitbake-layers remove-layer", 1)[1].split(" && ", 1)[0]
+
+        # obsolete layer must be removed
+        self.assertIn(shlex.quote(obsolete_abs), rm_seg)
+
+        # no add-layer command is needed
+        self.assertNotIn("bitbake-layers add-layer", cmd)
+
+        # managed layer state was updated
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_only_adds_missing_layer(self):
+        """
+        Stamp exists and YAML has more layers:
+        - no layers are removed
+        - missing layer is added
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+
+        # show-layers output contains only the first managed layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"fake1  {layers_abs[0]} 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers", return_value=[layers_abs[0]]), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> add missing layer
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # no remove-layer command is needed
+        self.assertNotIn("bitbake-layers remove-layer", cmd)
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # missing layer must be added
+        self.assertIn(shlex.quote(layers_abs[1]), add_seg)
+
+        # managed layer state was updated
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_layers_with_spaces_are_quoted(self):
+        """
+        Stamp exists and YAML layer path contains spaces:
+        - no layers are removed
+        - missing layer with spaces is added
+        - layer path and stamp path are shell-quoted
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake layer with spaces"]
+        stamp_path = "/tmp/layers stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+
+        # show-layers output contains only externally managed layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers", return_value=[]), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> add quoted layer
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # no remove-layer command is needed
+        self.assertNotIn("bitbake-layers remove-layer", cmd)
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # layer path with spaces must be shell-quoted
+        self.assertIn(shlex.quote(layers_abs[0]), add_seg)
+
+        # managed layer state must be written
+        mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_stamp_exists_differs_and_reorders_layers(self):
+        """
+        Stamp exists and simple add/remove would not preserve YAML order:
+        - obsolete layer is removed
+        - existing managed layer is removed because full recreate is needed
+        - YAML layers are added back in YAML order
+        - managed layer state is updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+        obsolete_abs = str((build_abs / "../obsolete-layer").resolve(strict=False))
+
+        # show-layers output contains one managed layer and one obsolete managed layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"fake2  {layers_abs[1]} 5\n"
+            f"obsolete  {obsolete_abs} 5\n"
+        )
+
+        # stamp exists -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._read_managed_layers",
+             return_value=[layers_abs[1], obsolete_abs]), \
+             patch("moulin.builders.yocto._write_managed_layers") as mock_write:
+
+            # 1st call -> show-layers, 2nd -> recreate managed layers in YAML order
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args_list[-1][0][0]
+
+        # check remove-layer segment
+        self.assertIn("bitbake-layers remove-layer", cmd)
+        rm_seg = cmd.split("bitbake-layers remove-layer", 1)[1].split(" && ", 1)[0]
+
+        # obsolete layer and existing managed layer must be removed
+        self.assertIn(shlex.quote(obsolete_abs), rm_seg)
+        self.assertIn(shlex.quote(layers_abs[1]), rm_seg)
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # YAML layers must be added back
+        self.assertIn(shlex.quote(layers_abs[0]), add_seg)
+        self.assertIn(shlex.quote(layers_abs[1]), add_seg)
+
+        # YAML layers must be added back in YAML order
+        self.assertLess(
+            add_seg.index(shlex.quote(layers_abs[0])),
+            add_seg.index(shlex.quote(layers_abs[1])),
+        )
+
+        # managed layer state was updated
+        mock_write.assert_called_once_with(stamp_path, layers_abs)

--- a/tests/unittest/test_utility_builders_yocto_sync_layers.py
+++ b/tests/unittest/test_utility_builders_yocto_sync_layers.py
@@ -1,0 +1,124 @@
+import unittest
+from unittest.mock import patch, Mock
+import moulin.builders.yocto as yocto_mod
+from pathlib import Path
+
+
+class TestYoctoUtilitySyncLayers(unittest.TestCase):
+    def test_first_run_no_stamp_calls_add_layer(self):
+        """
+        First run (stamp file does not exist):
+        - correct list of layers is passed to "bitbake-layers add-layer"
+        - stamp file is updated via "touch"
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # stamp file does not exist -> return_value=False
+        with patch("moulin.builders.yocto.Path.exists", return_value=False), \
+             patch("moulin.builders.yocto._run_bash") as mock_run:
+
+            mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args[0][0]
+
+        # cmd contains bitbake-layers add-layer and all layers
+        self.assertIn("bitbake-layers add-layer", cmd)
+        for layer in layers:
+            self.assertIn(layer, cmd)
+
+        # stamp file was updated
+        self.assertIn(f"touch {stamp_path}", cmd)
+
+    def test_stamp_exists_sync_layers(self):
+        """
+        Stamp exists:
+        - unneeded layer removed (ABS path)
+        - needed layers added (ABS paths)
+        - stamp updated
+        """
+        # create variables needed for the test
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        layers = ["../fake-layer1", "../fake-layer2"]
+        stamp_path = "/tmp/layers.stamp"
+
+        # -> this one is *not* in layers and must be removed
+        unneeded_rel = "../current-fake-layer"
+
+        # absolute forms (code may add/remove by ABS)
+        build_abs = (Path(yocto_dir) / work_dir).resolve(strict=False)
+        layers_abs = [str((build_abs / r).resolve(strict=False)) for r in layers]
+        unneeded_abs = str((build_abs / unneeded_rel).resolve(strict=False))
+
+        # Realistic show-layers output: 3 Yocto core layers + one unneeded managed layer
+        show_layers_stdout = (
+            "layer   path                    priority\n"
+            "========================================\n"
+            f"meta   {yocto_dir}/poky/meta           7\n"
+            f"meta   {yocto_dir}/poky/meta-poky      5\n"
+            f"meta   {yocto_dir}/poky/meta-yocto-bsp 5\n"
+            f"meta   {unneeded_abs} 5\n"
+        )
+
+        # stamp exist -> return_value=True
+        with patch("moulin.builders.yocto.Path.exists", return_value=True), \
+             patch("moulin.builders.yocto._run_bash") as mock_run:
+
+            # 1st call -> show-layers, 2nd -> apply diff
+            mock_run.side_effect = [
+                Mock(returncode=0, stdout=show_layers_stdout, stderr=""),
+                Mock(returncode=0, stdout="", stderr=""),
+            ]
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        # check command is not None
+        self.assertIsNotNone(mock_run.call_args)
+
+        # take the command passed to _run_bash
+        cmd = mock_run.call_args[0][0]
+
+        # check remove-layer segment
+        self.assertIn("bitbake-layers remove-layer", cmd)
+        rm_seg = cmd.split("bitbake-layers remove-layer", 1)[1].split(" && ", 1)[0]
+        # unneeded_abs must be present in remove
+        self.assertIn(unneeded_abs, rm_seg, msg=f"{unneeded_abs} \
+            not found in remove-layer segment:\n{rm_seg}")
+
+        # check add-layer segment
+        self.assertIn("bitbake-layers add-layer", cmd)
+        add_seg = cmd.split("bitbake-layers add-layer", 1)[1].split(" && ", 1)[0]
+
+        # all layers_abs must be in add-layer
+        for p in layers_abs:
+            self.assertIn(p, add_seg, msg=f"{p} not found in add-layer segment:\n{add_seg}")
+        # there shouldn't be unneeded_abs there
+        self.assertNotIn(unneeded_abs, add_seg, msg=f"{unneeded_abs} \
+            must NOT be in add-layer segment:\n{add_seg}")
+
+        # stamp file was updated
+        self.assertIn(f"touch {stamp_path}", cmd)


### PR DESCRIPTION
Introduce internal utility dispatch and Yocto layer synchronization

This PR adds a generic internal --utility-* dispatch mechanism to Moulin. Utility invocations are detected before normal argument parsing and are forwarded to the corresponding builder-provided handler. The default build configuration flow remains unchanged when no utility option is used.

The Yocto builder now uses this mechanism to synchronize active BitBake layers with the layer list defined in the Moulin YAML manifest.

The Yocto synchronization utility:

- stores the list of Moulin-managed layers in a stamp/state file;
- synchronizes only Moulin-managed layers;
- leaves externally managed layers untouched;
- adds missing YAML layers;
- removes layers that were previously managed but disappeared from the YAML manifest;
- recreates managed layers when needed to preserve the YAML layer order.

Also added unit tests covering:

- Initial synchronization (no stamp file).
- External layers.
- Layer removal.
- Layer addition.
- Layer addition and removal.
- No-op synchronization.
- Layer reordering.
- Layer recreation to preserve YAML order.
- Shell quoting for layer paths containing spaces.

Documentation was updated to describe the internal --utility-* mechanism and clarify that these options are intended for internal use only.