### PR TITLE
Replace `Logger.warn()` with `Logger.warning()`

### DIFF
--- a/moulin/main.py
+++ b/moulin/main.py
@@ -71,7 +71,7 @@ def _get_conf_file(conf_location: str) -> str:
         local_filename = os.path.basename(unquote(parsed_url.path))
         if os.path.exists(local_filename):
             # preserve possible local changes
-            log.warn("Local copy already exists. Nothing has been downloaded.")
+            log.warning("Local copy already exists. Nothing has been downloaded.")
         else:
             log.info("Downloading from URL...")
             urllib.request.urlretrieve(conf_location, local_filename)

--- a/moulin/rouge/block_entry.py
+++ b/moulin/rouge/block_entry.py
@@ -279,7 +279,7 @@ class FileSystem(BlockEntry):
 
         files_node = self._node.get("files", None)
         if files_node:
-            log.warn("Usage of 'files' is deprecated. Use 'items' please.")
+            log.warning("Usage of 'files' is deprecated. Use 'items' please.")
             for remote_name, local_node in cast(YamlValue, files_node).items():
                 self._items.append((remote_name, local_node.as_str, local_node.mark))
 
@@ -377,7 +377,7 @@ class Vfat(FileSystem):
                     for filename in filenames:
                         # we skip symlinks as not supported on vfat
                         if os.path.islink(os.path.join(dirpath, filename)):
-                            log.warn("Symlink '%s' is skipped.", os.path.join(dirpath, filename))
+                            log.warning("Symlink '%s' is skipped.", os.path.join(dirpath, filename))
                         else:
                             out_list.append([os.path.join(remote_dirpath, filename),
                                              os.path.join(dirpath, filename), mark])

--- a/moulin/rouge/gpti.py
+++ b/moulin/rouge/gpti.py
@@ -78,7 +78,7 @@ def create_mbr(partitions: List[Any]):
     # Count partitions
     part_count = len(partitions)
     if part_count > 3:
-        log.warn(
+        log.warning(
             f"There are {part_count} partitions in the partition table, but Hybrid MBR will contain only first 3"
         )
 


### PR DESCRIPTION
This commit address the following issue:
The method `warn` in class `Logger` is deprecated
since Python 3.3. Use `Logger.warning()` instead.