### PR TITLE
yocto: add support of openembedded Yocto distro

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -417,11 +417,13 @@ in the next subsections.
 yocto builder
 ^^^^^^^^^^^^^
 
-Yocto builder is used to build OpenEmbedded-based images. It expects
-that `poky` repository is cloned in :code:`{build_dir}/poky` and uses
-it's :code:`poky/oe-init-build-env` script to initialize build
-environment. Then :code:`bitbake-layers` tool is used to add
-additional layers and :code:`bitbake` used to perform the build.
+Yocto builder is used to build OpenEmbedded-based images. It supports two Yocto
+distributions: `poky` and `openembedded-core`. It expects that `poky`
+repository is cloned in :code:`{build_dir}/poky` whereas
+`openembedded-core` is cloned in :code:`{build_dir}/openembedded-core` and uses
+its :code:`oe-init-build-env` script to initialize build environment. Then
+:code:`bitbake-layers` tool is used to add additional layers and :code:`bitbake`
+used to perform the build.
 
 .. code-block:: yaml
 
@@ -429,6 +431,7 @@ additional layers and :code:`bitbake` used to perform the build.
     type: yocto       # Should be `yocto`
     work_dir: "build" # Optional
     build_target: core-image-minimal # Mandatory
+    distro: openembedded # Optional, default is `poky`
     conf:             # Mandatory
       - [MACHINE, "machine-name"]
       - [DISTRO_FEATURES_remove, "feature_to_remove"]
@@ -476,6 +479,10 @@ needed if you are building multiple VMs with cross-dependencies.
   "build". This is where files like "conf/local.conf" are stored. You
   can overwrite so you can produce multiple builds from the same (or
   different) set of Yocto layers.
+
+* :code:`distro` - Yocto distribution. Supported values are
+  :code:`poky` and :code:`openembedded`. The default value is
+  :code:`poky`.
 
 * :code:`additional_deps` - list of additional dependencies. This is
   basically :code:`target_images` produced by other components. You

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -33,7 +33,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     # Create build dir by calling poky/oe-init-build-env script
     cmd = " && ".join([
         "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
+        "source $init_script $work_dir",
     ])
     generator.rule("yocto_init_env",
                    command=f'bash -c "{cmd}"',
@@ -44,7 +44,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     # Add bitbake layers by calling bitbake-layers script
     cmd = " && ".join([
         "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
+        "source $init_script $work_dir",
         "bitbake-layers add-layer $layers",
         "touch $out",
     ])
@@ -76,7 +76,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
         # Generate fetcher dependency file
         construct_fetcher_dep_cmd(),
         "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
+        "source $init_script $work_dir",
         "bitbake $target",
     ])
     generator.rule("yocto_build",
@@ -189,6 +189,11 @@ class YoctoBuilder:
         #   directories. It is called "build" by default
         self.yocto_dir = build_dir
         self.work_dir: str = conf.get("work_dir", "build").as_str
+        self.distro = conf.get("distro", "poky").as_str
+        if self.distro not in ("poky", "openembedded"):
+            raise ValueError(
+                f"Unsupported Yocto distro '{self.distro}'. Supported distros are: 'poky', 'openembedded'."
+            )
 
     def _get_external_src(self) -> List[Tuple[str, str]]:
         external_src_node = self.conf.get("external_src", None)
@@ -211,6 +216,8 @@ class YoctoBuilder:
         common_variables = {
             "yocto_dir": self.yocto_dir,
             "work_dir": self.work_dir,
+            "init_script": "poky/oe-init-build-env" if self.distro == "poky"
+            else "openembedded-core/oe-init-build-env",
         }
 
         # First we need to ensure that "conf" dir exists
@@ -233,7 +240,10 @@ class YoctoBuilder:
         layers_node = self.conf.get("layers", None)
         if layers_node:
             layers_stamp = create_stamp_name(self.yocto_dir, self.work_dir, "yocto", "layers")
-            layers = " ".join(_filter_yocto_core_layers(_flatten_layers(layers_node)))
+            layers_list = _flatten_layers(layers_node)
+            if self.distro == "poky":
+                layers_list = _filter_yocto_core_layers(layers_list)
+            layers = " ".join(layers_list)
             self.generator.build(layers_stamp,
                                  "yocto_add_layers",
                                  env_target,


### PR DESCRIPTION
Poky distro is no longer updated. See
https://git.yoctoproject.org/poky/tree/README for details. Add support of individual clones of bitbake, openembedded-core and meta-yocto. Behaviour is switched by `distro` option in Yocto builder config. By default Poky distro is supported. To switch to new individual clones approach the project yaml should contain the following options:

sources:
  - type: git url: "https://git.openembedded.org/bitbake" rev: "master"
  - type: git url: "https://git.openembedded.org/openembedded-core" rev: "master"
  - type: git url: "https://git.yoctoproject.org/meta-yocto" rev: "master" ...

builder:
  type: yocto
  distro: openembedded
  layers:
    - "../openembedded-core/meta"
    - "../meta-yocto/meta-poky"
    - "../meta-yocto/meta-yocto-bsp" ...