### PR TITLE
fetchers: repo: Add git-lfs option

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -302,6 +302,8 @@ list of supported options:
   code storage. If it is missing, `moulin` will use :code:`"."` to
   initialize `repo` repository right in the component's build directory,
   as this is a main `repo` use case.
+* :code:`git_lfs` - optional - set to true to enable git-lfs. Corresponds to `repo`'s --git-lfs init
+  option.
 
 
 http fetcher

--- a/moulin/fetchers/repo.py
+++ b/moulin/fetchers/repo.py
@@ -62,6 +62,9 @@ class RepoFetcher:
         groups = self.conf.get("groups", "").as_str
         if groups:
             repo_args.append(f"-g {groups}")
+        git_lfs = self.conf.get("git_lfs", False).as_bool
+        if git_lfs:
+            repo_args.append("--git-lfs")
 
         init_target = os.path.join(self.repo_dir, ".repo")
         sync_stamp = create_stamp_name(self.build_dir, self.url, "sync")


### PR DESCRIPTION
This adds a git-lfs option to the repo fetcher to support repositories that use git-lfs.