### PR TITLE
builders: yocto: add support for other base distros

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2024, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.28'
+release = 'v0.29'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -427,6 +427,7 @@ additional layers and :code:`bitbake` used to perform the build.
 
   builder:
     type: yocto       # Should be `yocto`
+    base_distro: poky # Optional
     work_dir: "build" # Optional
     build_target: core-image-minimal # Mandatory
     conf:             # Mandatory
@@ -459,6 +460,12 @@ Mandatory options:
 
 Optional parameters. Those provide advanced features that may be
 needed if you are building multiple VMs with cross-dependencies.
+
+* :code:`base_distro` - provides name of base distro
+  directory. Default value is :code:`poky` for compatibility reasons.
+  For newer Yocto releases you want to use :code:`openembedded-core`.
+  Currently this only affects location of :code:`oe-init-build-env`
+  script.
 
 * :code:`conf` - list of additional :code:`local.conf` options. Please
   note that each entry in :code:`conf` list is not a :code:`key:value`

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -14,7 +14,7 @@ from moulin.yaml_helpers import YAMLProcessingError
 import logging
 
 
-YOCTO_CORE_LAYERS = ["../poky/meta", "../poky/meta-poky", "../poky/meta-yocto-bsp"]
+YOCTO_CORE_LAYERS = ["../poky/meta", "../poky/meta-poky", "../poky/meta-yocto-bsp", "../openembedded-core/meta"]
 log = logging.getLogger(__name__)
 
 
@@ -33,7 +33,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     # Create build dir by calling poky/oe-init-build-env script
     cmd = " && ".join([
         "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
+        "source $distro_dir/oe-init-build-env $work_dir",
     ])
     generator.rule("yocto_init_env",
                    command=f'bash -c "{cmd}"',
@@ -44,7 +44,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     # Add bitbake layers by calling bitbake-layers script
     cmd = " && ".join([
         "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
+        "source $distro_dir/oe-init-build-env $work_dir",
         "bitbake-layers add-layer $layers",
         "touch $out",
     ])
@@ -76,7 +76,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
         # Generate fetcher dependency file
         construct_fetcher_dep_cmd(),
         "cd $yocto_dir",
-        "source poky/oe-init-build-env $work_dir",
+        "source $distro_dir/oe-init-build-env $work_dir",
         "bitbake $target",
     ])
     generator.rule("yocto_build",
@@ -142,6 +142,11 @@ By default, Poky adds the following layers:
 "meta-poky"
 "meta-yocto-bsp"
 
+Newer version of OpenEmbedded shuffled layers a bit
+and now we don't have "poky" dir at all, but we still have
+
+"openembedded-core/meta"
+
 For more details, you can find information about it here:
 https://github.com/yoctoproject/poky/blob/807831067405a465886593df4e3057d3846a0001/documentation/
 migration-guides/migration-1.3.rst#bblayersconf
@@ -184,11 +189,12 @@ class YoctoBuilder:
         # With yocto builder it is possible to have multiple builds with the same set of
         # layers. Thus, we have two variables - build_dir and work_dir
         # - yocto_dir is the upper directory where layers are stored. Basically, we should
-        #   have "poky" in our yocto_dir
+        #   have core layers  in our yocto_dir
         # - work_dir is the build directory where we can find conf/local.conf, tmp and other
         #   directories. It is called "build" by default
         self.yocto_dir = build_dir
         self.work_dir: str = conf.get("work_dir", "build").as_str
+        self.base_distro: str = conf.get("base_distro", "poky").as_str
 
     def _get_external_src(self) -> List[Tuple[str, str]]:
         external_src_node = self.conf.get("external_src", None)
@@ -211,6 +217,7 @@ class YoctoBuilder:
         common_variables = {
             "yocto_dir": self.yocto_dir,
             "work_dir": self.work_dir,
+            "distro_dir": self.base_distro,
         }
 
         # First we need to ensure that "conf" dir exists

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.28',  # Required
+    version='0.29',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Do not assume that "poky" is the only available base distro name,
especially taking into account that newer versions of Poky use
openembedded-core as the name of the base distribution.