### PR TITLE
west: pass git options to west init

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install flake8 pytest pyaml
+        pip3 install flake8 pytest pyaml west
         # Needed by pygit package
         sudo apt-get install python3-pygit2
         # Needed by moulin integration tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2024, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.30'
+release = 'v0.31'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -371,6 +371,8 @@ Complete list of supported options:
   url: https://manifest.address/zephyr
   rev: manifest-revision
   file: manifest-file.yml
+  git_options:
+    - "--depth=1"
 
 * :code:`type` - mandatory - should be :code:`west` to enable `west` fetcher.
 * :code:`url` - optional - manifest repository URL. You can provide
@@ -380,6 +382,10 @@ Complete list of supported options:
   :code:`--mr` option.
 * :code:`file` - optional - manifest file name. Corresponds to `west init`'s
   :code:`--mf` option.
+* :code:`git_options` - optional - list of additional git clone options for
+  the manifest repository. Each list item is passed to :code:`west init` as
+  a separate :code:`-o` option. For example, :code:`"--depth=1"` produces
+  :code:`west init ... -o=--depth=1`.
 
 For additional details, see documentation on `west init`:
 https://docs.zephyrproject.org/latest/develop/west/built-in.html#west-init

--- a/moulin/fetchers/west.py
+++ b/moulin/fetchers/west.py
@@ -67,6 +67,8 @@ class WestFetcher:
         filename = self.conf.get("file", "").as_str
         if filename:
             west_args.append(f"--mf {shlex.quote(filename)}")
+        for option in self.conf.get("git_options", []):
+            west_args.append(f"-o={shlex.quote(option.as_str)}")
 
         init_target = os.path.join(self.build_dir, ".west")
         update_target = create_stamp_name(self.build_dir, "update")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.30',  # Required
+    version='0.31',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/integration_tests/west_fetcher/test_git_options/resources/test_git_options.yaml
+++ b/tests/integration_tests/west_fetcher/test_git_options/resources/test_git_options.yaml
@@ -1,0 +1,15 @@
+desc: "Test west fetcher git options"
+min_ver: "0.20"
+
+components:
+  test:
+    build-dir: workspace
+    builder:
+      type: "null"
+    sources:
+      - type: west
+        url: "%{MANIFEST_REPO_URL}"
+        rev: main
+        file: west.yml
+        git_options:
+          - "--depth=1"

--- a/tests/integration_tests/west_fetcher/test_git_options/test_git_options.py
+++ b/tests/integration_tests/west_fetcher/test_git_options/test_git_options.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+def run_cmd(args, cwd):
+    result = subprocess.run(args,
+                            cwd=cwd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True)
+    assert result.returncode == 0, (
+        f"Command failed: {' '.join(args)}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return result
+
+
+def init_git_repo(path):
+    os.makedirs(path)
+    run_cmd(["git", "init", "-b", "main"], path)
+    run_cmd(["git", "config", "user.name", "Moulin Test"], path)
+    run_cmd(["git", "config", "user.email", "moulin-test@example.com"], path)
+
+
+def commit_file(repo_path, filename, content, message):
+    file_path = os.path.join(repo_path, filename)
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as stream:
+        stream.write(content)
+    run_cmd(["git", "add", filename], repo_path)
+    run_cmd(["git", "commit", "-m", message], repo_path)
+
+
+def clone_bare(source_path, target_path, cwd):
+    run_cmd(["git", "clone", "--bare", source_path, target_path], cwd)
+
+
+@pytest.mark.integration
+def test_west_fetcher_git_options():
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    moulin_path = os.path.abspath(os.path.join(script_dir_path, "../../../../moulin.py"))
+    yaml_template = os.path.join(script_dir_path, "resources/test_git_options.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+        project_repo = os.path.join(tmp_dir, "project")
+        project_remote = os.path.join(tmp_dir, "project.git")
+        manifest_repo = os.path.join(tmp_dir, "manifest")
+        manifest_remote = os.path.join(tmp_dir, "manifest.git")
+        build_dir = os.path.join(tmp_dir, "build")
+
+        init_git_repo(project_repo)
+        commit_file(project_repo, "README", "first\n", "project: first")
+        commit_file(project_repo, "README", "second\n", "project: second")
+        clone_bare(project_repo, project_remote, tmp_dir)
+
+        init_git_repo(manifest_repo)
+        manifest = f"""manifest:
+  projects:
+    - name: project
+      url: file://{project_remote}
+      revision: main
+      path: project
+"""
+        commit_file(manifest_repo, "west.yml", manifest, "manifest: add project")
+        clone_bare(manifest_repo, manifest_remote, tmp_dir)
+
+        os.makedirs(build_dir)
+        manifest_repo_url = f"file://{manifest_remote}"
+        yaml_file = os.path.join(build_dir, "test_git_options.yaml")
+        with open(yaml_template, encoding="utf-8") as stream:
+            yaml_content = stream.read().replace("%{MANIFEST_REPO_URL}", manifest_repo_url)
+        with open(yaml_file, "w", encoding="utf-8") as stream:
+            stream.write(yaml_content)
+
+        result = subprocess.run([sys.executable, moulin_path, yaml_file],
+                                cwd=build_dir,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        assert result.returncode == 0, (
+            f"moulin failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        with open(os.path.join(build_dir, "build.ninja"), encoding="utf-8") as stream:
+            build_ninja = stream.read()
+        assert "-o=--depth=1" in build_ninja
+
+        result = subprocess.run(["ninja", "workspace/.west"],
+                                cwd=build_dir,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        assert result.returncode == 0, (
+            f"ninja failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        result = run_cmd(["git", "rev-parse", "--is-shallow-repository"],
+                         os.path.join(build_dir, "workspace/manifest.git"))
+        assert result.stdout.strip() == "true"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Add YAML support for git_options in the Moulin west fetcher. The options are passed to west init as repeated -o=<option> arguments, matching upstream west commit
zephyrproject-rtos/west@4a2c6bba689c656d46cae80889a686b23e9980c1