### PR TITLE
Add west group_filter support

### DIFF
--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -373,6 +373,7 @@ Complete list of supported options:
   file: manifest-file.yml
   git_options:
     - "--depth=1"
+  group_filter: "-group1,+group2"
 
 * :code:`type` - mandatory - should be :code:`west` to enable `west` fetcher.
 * :code:`url` - optional - manifest repository URL. You can provide
@@ -386,6 +387,22 @@ Complete list of supported options:
   the manifest repository. Each list item is passed to :code:`west init` as
   a separate :code:`-o` option. For example, :code:`"--depth=1"` produces
   :code:`west init ... -o=--depth=1`.
+* :code:`group_filter` - optional - west group filter expression or list of
+  expressions. Items are joined with commas and stored as
+  :code:`manifest.group-filter` in the west workspace before
+  :code:`west update` is executed. For example, :code:`"-group1,+group2"`
+  produces :code:`manifest.group-filter=-group1,+group2`. Both scalar string
+  and YAML list forms are supported:
+
+  .. code-block:: yaml
+
+    group_filter: "-group1,+group2"
+
+  .. code-block:: yaml
+
+    group_filter:
+      - "-group1"
+      - "+group2"
 
 For additional details, see documentation on `west init`:
 https://docs.zephyrproject.org/latest/develop/west/built-in.html#west-init

--- a/moulin/fetchers/west.py
+++ b/moulin/fetchers/west.py
@@ -35,6 +35,9 @@ def gen_build_rules(generator: ninja_syntax.Writer):
     # See `west help update` for additional info.
     cmd = " && ".join([
         "cd $build_dir",
+        "if [ -n \"$group_filter\" ]; then "
+        "west config manifest.group-filter \"$group_filter\"; "
+        "else west config -d --local manifest.group-filter || true; fi",
         "west update -n",
         "touch $out",
     ])
@@ -69,6 +72,11 @@ class WestFetcher:
             west_args.append(f"--mf {shlex.quote(filename)}")
         for option in self.conf.get("git_options", []):
             west_args.append(f"-o={shlex.quote(option.as_str)}")
+        group_filter_node = self.conf.get("group_filter", "")
+        if group_filter_node.is_list:
+            group_filter = ",".join([group.as_str for group in group_filter_node])
+        else:
+            group_filter = group_filter_node.as_str
 
         init_target = os.path.join(self.build_dir, ".west")
         update_target = create_stamp_name(self.build_dir, "update")
@@ -85,7 +93,8 @@ class WestFetcher:
                              "west_update",
                              init_target,
                              variables={
-                                 "build_dir": self.build_dir
+                                 "build_dir": self.build_dir,
+                                 "group_filter": group_filter,
                              })
         self.generator.newline()
 

--- a/tests/integration_tests/west_fetcher/test_group_filter/resources/test_group_filter.yaml
+++ b/tests/integration_tests/west_fetcher/test_group_filter/resources/test_group_filter.yaml
@@ -1,0 +1,14 @@
+desc: "Test west fetcher group filter"
+min_ver: "0.20"
+
+components:
+  test:
+    build-dir: workspace
+    builder:
+      type: "null"
+    sources:
+      - type: west
+        url: "%{MANIFEST_REPO_URL}"
+        rev: main
+        file: west.yml
+%{GROUP_FILTER}

--- a/tests/integration_tests/west_fetcher/test_group_filter/test_group_filter.py
+++ b/tests/integration_tests/west_fetcher/test_group_filter/test_group_filter.py
@@ -1,0 +1,155 @@
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+def run_cmd(args, cwd):
+    result = subprocess.run(args,
+                            cwd=cwd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True)
+    assert result.returncode == 0, (
+        f"Command failed: {' '.join(args)}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return result
+
+
+def init_git_repo(path):
+    os.makedirs(path)
+    run_cmd(["git", "init", "-b", "main"], path)
+    run_cmd(["git", "config", "user.name", "Moulin Test"], path)
+    run_cmd(["git", "config", "user.email", "moulin-test@example.com"], path)
+
+
+def commit_file(repo_path, filename, content, message):
+    file_path = os.path.join(repo_path, filename)
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as stream:
+        stream.write(content)
+    run_cmd(["git", "add", filename], repo_path)
+    run_cmd(["git", "commit", "-m", message], repo_path)
+
+
+GROUP_FILTER = "+kept,-dropped"
+GROUP_FILTER_STRING = f'        group_filter: "{GROUP_FILTER}"'
+GROUP_FILTER_LIST = "\n".join([
+    "        group_filter:",
+    "          - \"+kept\"",
+    "          - \"-dropped\"",
+])
+
+
+def create_bare_remote(source_path, target_path, cwd):
+    run_cmd(["git", "clone", "--bare", source_path, target_path], cwd)
+
+
+@pytest.mark.parametrize(
+    "group_filter_yaml",
+    [
+        GROUP_FILTER_STRING,
+        GROUP_FILTER_LIST,
+    ],
+    ids=["string", "list"],
+)
+@pytest.mark.integration
+def test_west_fetcher_group_filter(group_filter_yaml):
+    script_path = os.path.abspath(__file__)
+    script_dir_path = os.path.dirname(script_path)
+    moulin_path = os.path.abspath(os.path.join(script_dir_path,
+                                               "../../../../moulin.py"))
+    yaml_template = os.path.join(script_dir_path,
+                                 "resources/test_group_filter.yaml")
+
+    with tempfile.TemporaryDirectory(dir=script_dir_path) as tmp_dir:
+        kept_repo = os.path.join(tmp_dir, "kept")
+        kept_remote = os.path.join(tmp_dir, "kept.git")
+        dropped_repo = os.path.join(tmp_dir, "dropped")
+        dropped_remote = os.path.join(tmp_dir, "dropped.git")
+        manifest_repo = os.path.join(tmp_dir, "manifest")
+        manifest_remote = os.path.join(tmp_dir, "manifest.git")
+        build_dir = os.path.join(tmp_dir, "build")
+
+        init_git_repo(kept_repo)
+        commit_file(kept_repo, "README", "kept\n", "kept: add README")
+        create_bare_remote(kept_repo, kept_remote, tmp_dir)
+
+        init_git_repo(dropped_repo)
+        commit_file(dropped_repo, "README", "dropped\n", "dropped: add README")
+        create_bare_remote(dropped_repo, dropped_remote, tmp_dir)
+
+        init_git_repo(manifest_repo)
+        manifest = f"""manifest:
+  projects:
+    - name: kept
+      url: file://{kept_remote}
+      revision: main
+      path: kept
+      groups:
+        - kept
+    - name: dropped
+      url: file://{dropped_remote}
+      revision: main
+      path: dropped
+      groups:
+        - dropped
+"""
+        commit_file(manifest_repo, "west.yml", manifest,
+                    "manifest: add projects")
+        create_bare_remote(manifest_repo, manifest_remote, tmp_dir)
+
+        os.makedirs(build_dir)
+        manifest_repo_url = f"file://{manifest_remote}"
+        yaml_file = os.path.join(build_dir, "test_group_filter.yaml")
+        with open(yaml_template, encoding="utf-8") as stream:
+            yaml_content = stream.read().replace("%{MANIFEST_REPO_URL}",
+                                                 manifest_repo_url)
+        yaml_content = yaml_content.replace("%{GROUP_FILTER}",
+                                            group_filter_yaml)
+        with open(yaml_file, "w", encoding="utf-8") as stream:
+            stream.write(yaml_content)
+
+        result = subprocess.run([sys.executable, moulin_path, yaml_file],
+                                cwd=build_dir,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        assert result.returncode == 0, (
+            f"moulin failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        with open(os.path.join(build_dir, "build.ninja"),
+                  encoding="utf-8") as stream:
+            build_ninja = stream.read()
+        assert f"group_filter = {GROUP_FILTER}" in build_ninja
+
+        result = subprocess.run(["ninja", "fetch-test"],
+                                cwd=build_dir,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        assert result.returncode == 0, (
+            f"ninja failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        result = run_cmd(["west", "config", "manifest.group-filter"],
+                         os.path.join(build_dir, "workspace"))
+        assert result.stdout.strip() == GROUP_FILTER
+
+        result = run_cmd(["west", "list", "--format={name}"],
+                         os.path.join(build_dir, "workspace"))
+        projects = result.stdout.splitlines()
+        assert "kept" in projects
+        assert "dropped" not in projects
+
+        assert os.path.isdir(os.path.join(build_dir, "workspace/kept/.git"))
+        assert not os.path.exists(os.path.join(build_dir, "workspace/dropped"))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Zephyr west manifests may use project groups to exclude optional
repositories from a workspace. Moulin did not expose west's
manifest.group-filter setting, so every project listed in the manifest was
fetched even when a build only needed a subset of groups.

Add a west fetcher group_filter option. The option accepts either the west
group filter expression as a string or a YAML list of expressions; list
items are joined with commas before being written to west config.

Before running west update, configure the workspace-local
manifest.group-filter value. If group_filter is not specified, remove the
local value to avoid reusing a stale filter from a previous run.

This follows west's manifest group filter semantics:
https://docs.zephyrproject.org/latest/develop/west/manifest.html#project-groups