### PR TITLE
yocto: pass base distro to layer sync utility & show captured subprocess errors

### DIFF
--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -340,12 +340,20 @@ def _env_prefix(yocto_dir: str, work_dir: str) -> str:
 
 def _run_bash(cmd: str, *, capture=False) -> subprocess.CompletedProcess:
     """Run a bash -lc command."""
-    return subprocess.run(
-        ["bash", "-lc", cmd],
-        check=True,
-        capture_output=capture,
-        text=capture,
-    )
+    try:
+        return subprocess.run(
+            ["bash", "-lc", cmd],
+            check=True,
+            capture_output=capture,
+            text=capture,
+        )
+    except subprocess.CalledProcessError as exc:
+        if capture:
+            if exc.stdout:
+                print(exc.stdout, end="", file=sys.stdout)
+            if exc.stderr:
+                print(exc.stderr, end="", file=sys.stderr)
+        raise
 
 
 def relative_paths_to_absolute(base: Path, rels: List[str]) -> List[str]:

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -54,6 +54,7 @@ def gen_build_rules(generator: ninja_syntax.Writer):
         f"{prog} "
         "--utility-builders-yocto "
         "--yocto-dir $yocto_dir "
+        "--distro-dir $distro_dir "
         "--work-dir $work_dir "
         "--layers $layers "
         "--stamp $out"
@@ -327,14 +328,14 @@ class YoctoBuilder:
         """
 
 
-def _env_prefix(yocto_dir: str, work_dir: str) -> str:
+def _env_prefix(yocto_dir: str, distro_dir: str, work_dir: str) -> str:
     """
     Return a shell snippet that cd's into yocto_dir and sources
     oe-init-build-env for work_dir.
     """
     return " && ".join([
         f"cd {shlex.quote(yocto_dir)}",
-        f". poky/oe-init-build-env {shlex.quote(work_dir)}",
+        f". {shlex.quote(distro_dir)}/oe-init-build-env {shlex.quote(work_dir)}",
     ])
 
 
@@ -480,6 +481,7 @@ def handle_utility_call(argv: List[str]) -> int:
     # Parse args
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--yocto-dir", required=True)  # path to Yocto root
+    parser.add_argument("--distro-dir", default="poky")  # path to distro inside Yocto root
     parser.add_argument("--work-dir", required=True)  # path to build dir
     parser.add_argument("--layers", nargs="+", required=True)  # YAML layers (relative to yocto root)
     parser.add_argument("--stamp", required=True)  # stamp file path
@@ -491,10 +493,11 @@ def handle_utility_call(argv: List[str]) -> int:
         for layer in args.layers
     )
     yocto_root = args.yocto_dir
+    distro_dir = args.distro_dir
     build_dir = args.work_dir
     stamp_out = args.stamp
     stamp_exists = Path(stamp_out).exists()
-    env_prefix = _env_prefix(yocto_root, build_dir)
+    env_prefix = _env_prefix(yocto_root, distro_dir, build_dir)
 
     # Compute absolute build path
     build_dir_path = Path(build_dir)

--- a/tests/unittest/test_utility_builders_yocto_sync_layers.py
+++ b/tests/unittest/test_utility_builders_yocto_sync_layers.py
@@ -1,8 +1,10 @@
 import unittest
 import shlex
+import subprocess
 from unittest.mock import patch, Mock
 import moulin.builders.yocto as yocto_mod
 from pathlib import Path
+from io import StringIO
 
 
 class TestYoctoUtilitySyncLayers(unittest.TestCase):
@@ -201,6 +203,23 @@ class TestYoctoUtilitySyncLayers(unittest.TestCase):
 
         # managed layer state was updated
         mock_write.assert_called_once_with(stamp_path, layers_abs)
+
+    def test_run_bash_prints_captured_output_on_failure(self):
+        failure = subprocess.CalledProcessError(
+            1,
+            ["bash", "-lc", "bitbake-layers show-layers"],
+            output="captured stdout\n",
+            stderr="captured stderr\n",
+        )
+
+        with patch("moulin.builders.yocto.subprocess.run", side_effect=failure), \
+             patch("sys.stdout", new_callable=StringIO) as stdout, \
+             patch("sys.stderr", new_callable=StringIO) as stderr:
+            with self.assertRaises(subprocess.CalledProcessError):
+                yocto_mod._run_bash("bitbake-layers show-layers", capture=True)
+
+        self.assertEqual(stdout.getvalue(), "captured stdout\n")
+        self.assertEqual(stderr.getvalue(), "captured stderr\n")
 
     def test_stamp_exists_identical_layers_no_add_or_remove(self):
         """

--- a/tests/unittest/test_utility_builders_yocto_sync_layers.py
+++ b/tests/unittest/test_utility_builders_yocto_sync_layers.py
@@ -221,6 +221,33 @@ class TestYoctoUtilitySyncLayers(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "captured stdout\n")
         self.assertEqual(stderr.getvalue(), "captured stderr\n")
 
+    def test_utility_uses_configured_distro_dir(self):
+        yocto_dir = "/abs/path/to/yocto"
+        work_dir = "build-dom0"
+        distro_dir = "openembedded-core"
+        layers = ["../fake-layer1"]
+        stamp_path = "/tmp/layers.stamp"
+
+        with patch("moulin.builders.yocto.Path.exists", return_value=False), \
+             patch("moulin.builders.yocto._run_bash") as mock_run, \
+             patch("moulin.builders.yocto._write_managed_layers"):
+
+            mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+
+            yocto_mod.handle_utility_call(
+                argv=[
+                    "--yocto-dir", yocto_dir,
+                    "--distro-dir", distro_dir,
+                    "--work-dir", work_dir,
+                    "--layers", *layers,
+                    "--stamp", stamp_path,
+                ],
+            )
+
+        cmd = mock_run.call_args_list[-1][0][0]
+        self.assertIn(". openembedded-core/oe-init-build-env build-dom0", cmd)
+        self.assertNotIn(". poky/oe-init-build-env build-dom0", cmd)
+
     def test_stamp_exists_identical_layers_no_add_or_remove(self):
         """
         Stamp exists and layers already match YAML:

--- a/tests/unittest/test_yocto_builder.py
+++ b/tests/unittest/test_yocto_builder.py
@@ -99,6 +99,42 @@ components:
         else:
             self.fail("Could not find yocto_build target")
 
+    def test_layer_sync_passes_distro_dir(self):
+        doc = """
+desc: "Test build"
+components:
+  test:
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      base_distro: openembedded-core
+      conf:
+      layers:
+        - "../meta-layer"
+      target_images:
+        - "target-image"
+    sources:
+      - type: "null"
+        """
+        node = yaml.compose(doc)
+        conf = MoulinConfiguration(node)
+        generate_build(conf, "test.yaml")
+
+        self.Writer.return_value.rule.assert_any_call(
+            "yocto_update_layers",
+            command=ANY,
+            description="Synchronize Yocto layers with a moulin configuration file",
+            pool="console",
+            restat=True,
+        )
+        for call in self.Writer.return_value.rule.call_args_list:
+            if call.args[0] == "yocto_update_layers":
+                command = call.kwargs["command"]
+                self.assertIn("--distro-dir $distro_dir", command)
+                break
+        else:
+            self.fail("Could not find yocto_update_layers rule")
+
     def test_target_images_expansion(self):
         doc = """
 desc: "Test build"


### PR DESCRIPTION
yocto: pass base distro to layer sync utility
Yocto build rules already source oe-init-build-env through the configured
base_distro value. The layer sync utility did not receive that value and
always sourced poky/oe-init-build-env internally.

This breaks OpenEmbedded-core based layouts, where the init script lives
under openembedded-core/oe-init-build-env and there is no poky directory.
Pass the generated distro_dir variable into the utility and keep poky as
the command-line default for compatibility with direct utility calls.

----

yocto: show captured subprocess errors
Yocto layer sync runs bitbake-layers show-layers with capture=True
when a managed-layers stamp already exists. If BitBake rejects the
current bblayers.conf, for example because it references a missing
layer, subprocess raises CalledProcessError but the captured
stdout/stderr are not printed.

As a result Moulin reports only the Python traceback and hides the
actionable Yocto diagnostic. Print captured output before re-raising so
the command still fails with the same behavior, but the real BitBake
error is visible in the build log.