### PR TITLE
yocto: exclude work dir from layer dependency scan

### DIFF
--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -186,6 +186,12 @@ your YAML Moulin configuration files.
     return result
 
 
+def _is_same_or_child_path(child_candidate: str, parent_candidate: str) -> bool:
+    child_candidate = os.path.abspath(os.path.normpath(child_candidate))
+    parent_candidate = os.path.abspath(os.path.normpath(parent_candidate))
+    return os.path.commonpath([child_candidate, parent_candidate]) == parent_candidate
+
+
 class YoctoBuilder:
     """
     YoctoBuilder class generates Ninja rules for given build configuration
@@ -303,13 +309,37 @@ class YoctoBuilder:
 
         deps: List[str] = []
         layers_base = os.path.join(self.yocto_dir, self.work_dir)
+        yocto_dir = os.path.abspath(os.path.normpath(self.yocto_dir))
+        work_dir = os.path.abspath(os.path.normpath(os.path.join(self.yocto_dir, self.work_dir)))
+
+        # work_dir='.' leaves no separate generated build dir to prune.
+        work_dir_can_be_pruned = work_dir != yocto_dir
         layers = _filter_yocto_core_layers(_flatten_layers(layers_node))
         for layer in layers:
             layer_path = os.path.normpath(os.path.join(layers_base, layer))
             if not os.path.isdir(layer_path):
                 raise YAMLProcessingError(f"Can't find Yocto layer directory '{layer_path}'",
                                           layers_node.mark)
-            for dirpath, _, filenames in os.walk(layer_path):
+
+            # A broad layer path can contain the Yocto build dir, for example
+            # layer_path=yocto with work_dir=yocto/build/secure-image.
+            work_dir_is_inside_layer = (work_dir_can_be_pruned
+                                        and _is_same_or_child_path(work_dir, layer_path))
+            if work_dir_is_inside_layer:
+                work_dir_parent = os.path.dirname(work_dir)
+                work_dir_basename = os.path.basename(work_dir)
+            else:
+                work_dir_parent = None
+                work_dir_basename = None
+
+            for dirpath, dirnames, filenames in os.walk(layer_path):
+                abs_dirpath = os.path.abspath(os.path.normpath(dirpath))
+                if (abs_dirpath == work_dir_parent
+                        and work_dir_basename in dirnames):
+                    # os.walk() is top-down, so removing the build dir name here
+                    # prevents traversal of generated trees such as buildhistory.
+                    dirnames.remove(work_dir_basename)
+
                 deps.extend(os.path.join(dirpath, filename) for filename in filenames)
         return deps
 

--- a/tests/unittest/test_build_dependencies.py
+++ b/tests/unittest/test_build_dependencies.py
@@ -130,6 +130,93 @@ components:
         self.assertIn("test/meta-product/conf/layer.conf", depfile)
         self.assertIn("test/meta-product/recipes-core/images/image.bb", depfile)
 
+    def test_yocto_layer_deps_exclude_work_dir_nested_under_layer(self):
+        """Verifies Yocto build dir nested under a layer is not tracked."""
+        doc = """
+desc: "Test build dependencies"
+components:
+  test:
+    sources:
+      - type: "null"
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      work_dir: yocto/meta-product/yocto/build/secure-image
+      conf:
+      target_images:
+        - "target-image"
+      layers:
+        # layers are relative to work_dir; this resolves to test/yocto/meta-product,
+        # which contains test/yocto/meta-product/yocto/build/secure-image.
+        - "../../.."
+        """
+
+        def setup():
+            layer_dir = "test/yocto/meta-product"
+            build_dir = os.path.join(layer_dir, "yocto/build/secure-image")
+
+            os.makedirs(os.path.join(layer_dir, "conf"))
+            os.makedirs(os.path.join(layer_dir, "recipes-core/images"))
+            os.makedirs(os.path.join(build_dir, "buildhistory/packages/acl"))
+            os.makedirs(os.path.join(build_dir, "tmp/work"))
+            with open(os.path.join(layer_dir, "conf/layer.conf"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("# layer configuration\n")
+            with open(os.path.join(layer_dir, "recipes-core/images/image.bb"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("DESCRIPTION = \"test image\"\n")
+            with open(os.path.join(build_dir, "buildhistory/packages/acl/latest"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("generated buildhistory\n")
+            with open(os.path.join(build_dir, "tmp/work/generated.bb"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("generated recipe\n")
+
+        depfile = self._generate_depfile(doc, setup=setup)
+
+        self.assertIn("test/yocto/meta-product/yocto/build/secure-image/target-image:",
+                      depfile)
+        self.assertIn("test/yocto/meta-product/conf/layer.conf", depfile)
+        self.assertIn("test/yocto/meta-product/recipes-core/images/image.bb", depfile)
+        self.assertNotIn("buildhistory/packages/acl/latest", depfile)
+        self.assertNotIn("test/yocto/meta-product/yocto/build/secure-image/tmp/work/generated.bb",
+                         depfile)
+
+    def test_yocto_layer_deps_keep_layer_nested_under_work_dir(self):
+        """Verifies explicitly configured layers inside work_dir remain tracked."""
+        doc = """
+desc: "Test build dependencies"
+components:
+  test:
+    sources:
+      - type: "null"
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      work_dir: build
+      conf:
+      target_images:
+        - "target-image"
+      layers:
+        - "generated-layer"
+        """
+
+        def setup():
+            os.makedirs("test/build/generated-layer/conf")
+            os.makedirs("test/build/generated-layer/recipes-core/images")
+            with open("test/build/generated-layer/conf/layer.conf", "w",
+                      encoding="utf-8") as stream:
+                stream.write("# generated layer configuration\n")
+            with open("test/build/generated-layer/recipes-core/images/image.bb", "w",
+                      encoding="utf-8") as stream:
+                stream.write("DESCRIPTION = \"generated layer image\"\n")
+
+        depfile = self._generate_depfile(doc, setup=setup)
+
+        self.assertIn("test/build/target-image:", depfile)
+        self.assertIn("test/build/generated-layer/conf/layer.conf", depfile)
+        self.assertIn("test/build/generated-layer/recipes-core/images/image.bb", depfile)
+
     def test_build_files_dependency_policy_rejects_unsupported_builder(self):
         """Verifies direct --dep rejects unsupported 'build_files' deps policy."""
         doc = """


### PR DESCRIPTION
Yocto layer dependency tracking walks configured layer directories after a build and writes the result to .moulin_<component>.d.

When a broad layer path also contains the active Yocto work directory, generated files such as buildhistory can be recorded as Ninja inputs and make the depfile huge.

Skip the active work directory while walking layer dependencies, but keep the existing work_dir='.' behavior where the work directory is the Yocto root itself.