### PR TITLE
yocto: prune Yocto generated and .git dirs from deps

### DIFF
--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -20,6 +20,22 @@ from pathlib import Path
 
 
 YOCTO_CORE_LAYERS = ["../poky/meta", "../poky/meta-poky", "../poky/meta-yocto-bsp", "../openembedded-core/meta"]
+# Moulin keeps the variable list, but BitBake provides the actual paths. TOPDIR
+# is set by BitBake; the other variables are OE-Core/Poky build directories
+# normally defined from TOPDIR/TMPDIR in meta/conf/bitbake.conf. BUILDHISTORY_DIR
+# is optional and exists only when buildhistory metadata is enabled.
+YOCTO_GENERATED_DIR_VARIABLES = [
+    "TOPDIR",
+    "TMPDIR",
+    "DL_DIR",
+    "SSTATE_DIR",
+    "PERSISTENT_DIR",
+    "CACHE",
+    "BUILDHISTORY_DIR",
+    "DEPLOY_DIR",
+    "PKGDATA_DIR",
+    "STAMPS_DIR",
+]
 log = logging.getLogger(__name__)
 
 
@@ -188,9 +204,75 @@ your YAML Moulin configuration files.
 
 
 def _is_same_or_child_path(child_candidate: str, parent_candidate: str) -> bool:
-    child_candidate = os.path.abspath(os.path.normpath(child_candidate))
-    parent_candidate = os.path.abspath(os.path.normpath(parent_candidate))
+    # realpath is required for product layers reached through symlinks, e.g.
+    # yocto/meta-product -> ../../meta-product, so generated build dirs are
+    # matched against their physical BitBake paths.
+    child_candidate = os.path.realpath(os.path.abspath(os.path.normpath(child_candidate)))
+    parent_candidate = os.path.realpath(os.path.abspath(os.path.normpath(parent_candidate)))
     return os.path.commonpath([child_candidate, parent_candidate]) == parent_candidate
+
+
+def _get_yocto_generated_dirs(yocto_dir: str, distro_dir: str, work_dir: str) -> List[str]:
+    env_prefix = _env_prefix(yocto_dir, distro_dir, work_dir, quiet=True)
+    paths: List[str] = []
+    for variable in YOCTO_GENERATED_DIR_VARIABLES:
+        cmd = " && ".join([
+            env_prefix,
+            f"bitbake-getvar --ignore-undefined --value {shlex.quote(variable)}",
+        ])
+        try:
+            value = _run_bash(cmd, capture=True).stdout.strip()
+        except (OSError, subprocess.CalledProcessError) as exc:
+            # Keep compatibility with BitBake versions that may miss a variable,
+            # but warn because an incomplete list can leave generated files in deps.
+            log.warning("Can't query BitBake generated directory variable %s: %s",
+                        variable, exc)
+            continue
+        if os.path.isabs(value):
+            # Only absolute paths can be safely compared with os.walk() results.
+            paths.append(os.path.realpath(os.path.abspath(os.path.normpath(value))))
+    return sorted(set(paths))
+
+
+def _get_layer_file_list(layer_path: str, generated_dirs: List[str]) -> List[str]:
+    """
+    Return layer files, excluding BitBake generated directories.
+
+    Args:
+        layer_path: Directory to scan for layer dependency files.
+        generated_dirs: Absolute generated directory paths reported by BitBake.
+            Matching child directories are removed from os.walk() in-place to
+            prevent descent into generated trees. The function prunes before
+            traversal, so generated trees are not enumerated file by file.
+
+    Returns:
+        Files below layer_path, except files located inside generated_dirs.
+    """
+    deps: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(layer_path):
+        if ".git" in dirnames:
+            dirnames.remove(".git")
+
+        abs_dirpath = os.path.realpath(os.path.abspath(os.path.normpath(dirpath)))
+        if any(_is_same_or_child_path(abs_dirpath, generated_dir)
+               for generated_dir in generated_dirs):
+            # Stop descent if the walk already entered a generated tree.
+            dirnames.clear()
+            continue
+
+        for generated_dir in generated_dirs:
+            if not _is_same_or_child_path(generated_dir, abs_dirpath):
+                continue
+            # Generated directory is inside the layer directory. Remove its
+            # next path segment from dirnames, because top-down os.walk() uses
+            # dirnames as the list of child directories it will visit next.
+            relative_path = os.path.relpath(generated_dir, abs_dirpath)
+            dirname = relative_path.split(os.sep, 1)[0]
+            if dirname in dirnames:
+                dirnames.remove(dirname)
+
+        deps.extend(os.path.join(dirpath, filename) for filename in filenames)
+    return deps
 
 
 class YoctoBuilder:
@@ -310,38 +392,23 @@ class YoctoBuilder:
 
         deps: List[str] = []
         layers_base = os.path.join(self.yocto_dir, self.work_dir)
-        yocto_dir = os.path.abspath(os.path.normpath(self.yocto_dir))
-        work_dir = os.path.abspath(os.path.normpath(os.path.join(self.yocto_dir, self.work_dir)))
-
-        # work_dir='.' leaves no separate generated build dir to prune.
-        work_dir_can_be_pruned = work_dir != yocto_dir
+        generated_dirs = _get_yocto_generated_dirs(self.yocto_dir, self.base_distro,
+                                                   self.work_dir)
         layers = _filter_yocto_core_layers(_flatten_layers(layers_node))
         for layer in layers:
             layer_path = os.path.normpath(os.path.join(layers_base, layer))
             if not os.path.isdir(layer_path):
                 raise YAMLProcessingError(f"Can't find Yocto layer directory '{layer_path}'",
                                           layers_node.mark)
+            generated_dirs_inside_layer_dir = [
+                generated_dir
+                for generated_dir in generated_dirs
+                if _is_same_or_child_path(generated_dir, layer_path)
+            ]
 
-            # A broad layer path can contain the Yocto build dir, for example
-            # layer_path=yocto with work_dir=yocto/build/secure-image.
-            work_dir_is_inside_layer = (work_dir_can_be_pruned
-                                        and _is_same_or_child_path(work_dir, layer_path))
-            if work_dir_is_inside_layer:
-                work_dir_parent = os.path.dirname(work_dir)
-                work_dir_basename = os.path.basename(work_dir)
-            else:
-                work_dir_parent = None
-                work_dir_basename = None
-
-            for dirpath, dirnames, filenames in os.walk(layer_path):
-                abs_dirpath = os.path.abspath(os.path.normpath(dirpath))
-                if (abs_dirpath == work_dir_parent
-                        and work_dir_basename in dirnames):
-                    # os.walk() is top-down, so removing the build dir name here
-                    # prevents traversal of generated trees such as buildhistory.
-                    dirnames.remove(work_dir_basename)
-
-                deps.extend(os.path.join(dirpath, filename) for filename in filenames)
+            # Prune generated dirs per containing layer, so explicit layers under
+            # work_dir remain trackable.
+            deps.extend(_get_layer_file_list(layer_path, generated_dirs_inside_layer_dir))
         return deps
 
     def get_targets(self):
@@ -358,14 +425,16 @@ class YoctoBuilder:
         """
 
 
-def _env_prefix(yocto_dir: str, distro_dir: str, work_dir: str) -> str:
+def _env_prefix(yocto_dir: str, distro_dir: str, work_dir: str, quiet: bool = False) -> str:
     """
     Return a shell snippet that cd's into yocto_dir and sources
     oe-init-build-env for work_dir.
     """
+    # Captured bitbake-getvar output must contain only the requested value.
+    stdout_redirect = " >/dev/null" if quiet else ""
     return " && ".join([
         f"cd {shlex.quote(yocto_dir)}",
-        f". {shlex.quote(distro_dir)}/oe-init-build-env {shlex.quote(work_dir)}",
+        f". {shlex.quote(distro_dir)}/oe-init-build-env {shlex.quote(work_dir)}{stdout_redirect}",
     ])
 
 

--- a/tests/integration_tests/yocto_builder/test_layer_dependency_tracking/resources/bin/bitbake-getvar
+++ b/tests/integration_tests/yocto_builder/test_layer_dependency_tracking/resources/bin/bitbake-getvar
@@ -1,0 +1,32 @@
+#!/bin/sh
+echo "$@" >> bitbake-getvar.log
+
+if [ "$1" = "-q" ]; then
+	shift
+fi
+
+if [ "$1" = "--ignore-undefined" ]; then
+	shift
+fi
+
+if [ "$1" = "--value" ]; then
+	shift
+fi
+
+case "$1" in
+TOPDIR)
+	pwd
+	;;
+TMPDIR)
+	printf '%s/tmp\n' "$(pwd)"
+	;;
+DL_DIR)
+	printf '%s/downloads\n' "$(pwd)"
+	;;
+SSTATE_DIR)
+	printf '%s/sstate-cache\n' "$(pwd)"
+	;;
+*)
+	:
+	;;
+esac

--- a/tests/integration_tests/yocto_builder/test_layer_dependency_tracking/test_layer_dependency_tracking.py
+++ b/tests/integration_tests/yocto_builder/test_layer_dependency_tracking/test_layer_dependency_tracking.py
@@ -76,7 +76,8 @@ class FakeYoctoBuild:
         shutil.copytree(self.resources_dir / "workspace", self.workspace)
         shutil.copytree(self.resources_dir / "bin", self.fake_bin)
         shutil.copy2(self.resources_dir / "build.yaml", self.yaml_file)
-        for tool in [self.fake_bin / "bitbake", self.fake_bin / "bitbake-layers"]:
+        tools = ["bitbake", "bitbake-getvar", "bitbake-layers"]
+        for tool in [self.fake_bin / name for name in tools]:
             tool.chmod(0o755)
 
     def _write_moulin_wrapper(self):

--- a/tests/unittest/test_build_dependencies.py
+++ b/tests/unittest/test_build_dependencies.py
@@ -16,6 +16,7 @@ from moulin import ninja_syntax
 from moulin.build_conf import MoulinConfiguration
 from moulin.build_generator import generate_build, generate_component_dyndep
 from moulin.main import moulin_entry
+from moulin.builders.yocto import _get_yocto_generated_dirs
 from moulin.builders.zephyr import ZephyrBuilder
 from moulin.yaml_helpers import YAMLProcessingError
 from moulin.yaml_wrapper import YamlValue
@@ -36,6 +37,17 @@ def _write_source_archive():
         stream.write("source contents\n")
     with tarfile.open("source.tar", "w") as archive:
         archive.add("source-file")
+
+
+def _write_yocto_layer(layer_dir):
+    os.makedirs(os.path.join(layer_dir, "conf"))
+    os.makedirs(os.path.join(layer_dir, "recipes-core/images"))
+    with open(os.path.join(layer_dir, "conf/layer.conf"), "w",
+              encoding="utf-8") as stream:
+        stream.write("# layer configuration\n")
+    with open(os.path.join(layer_dir, "recipes-core/images/image.bb"), "w",
+              encoding="utf-8") as stream:
+        stream.write("DESCRIPTION = \"test image\"\n")
 
 
 def _make_zephyr_builder():
@@ -74,6 +86,17 @@ class TestComponentDependencies(unittest.TestCase):
                     return stream.read()
             finally:
                 os.chdir(old_cwd)
+
+    def _generate_yocto_depfile(self, doc, setup=None):
+        generated_dirs = []
+
+        def setup_with_generated_dirs():
+            if setup:
+                generated_dirs.extend(setup() or [])
+
+        with patch("moulin.builders.yocto._get_yocto_generated_dirs",
+                   return_value=generated_dirs):
+            return self._generate_depfile(doc, setup=setup_with_generated_dirs)
 
     def test_default_dependency_policy_uses_fetched_files(self):
         """Verifies default dependency_policy uses legacy 'fetched_files' deps policy."""
@@ -116,19 +139,44 @@ components:
         """
 
         def setup():
-            os.makedirs("test/meta-product/conf")
-            os.makedirs("test/meta-product/recipes-core/images")
-            with open("test/meta-product/conf/layer.conf", "w", encoding="utf-8") as stream:
-                stream.write("# layer configuration\n")
-            with open("test/meta-product/recipes-core/images/image.bb", "w",
-                      encoding="utf-8") as stream:
-                stream.write("DESCRIPTION = \"test image\"\n")
+            _write_yocto_layer("test/meta-product")
 
-        depfile = self._generate_depfile(doc, setup=setup)
+        depfile = self._generate_yocto_depfile(doc, setup=setup)
 
         self.assertIn("test/build/target-image:", depfile)
         self.assertIn("test/meta-product/conf/layer.conf", depfile)
         self.assertIn("test/meta-product/recipes-core/images/image.bb", depfile)
+
+    def test_yocto_layer_deps_exclude_git_directory(self):
+        """Verifies Git metadata below a layer is not tracked."""
+        doc = """
+desc: "Test build dependencies"
+components:
+  test:
+    sources:
+      - type: "null"
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      conf:
+      target_images:
+        - "target-image"
+      layers:
+        - "../meta-product"
+        """
+
+        def setup():
+            _write_yocto_layer("test/meta-product")
+            os.makedirs("test/meta-product/.git/objects")
+            with open("test/meta-product/.git/objects/object", "w",
+                      encoding="utf-8") as stream:
+                stream.write("git object\n")
+
+        depfile = self._generate_yocto_depfile(doc, setup=setup)
+
+        self.assertIn("test/meta-product/conf/layer.conf", depfile)
+        self.assertIn("test/meta-product/recipes-core/images/image.bb", depfile)
+        self.assertNotIn("test/meta-product/.git/objects/object", depfile)
 
     def test_yocto_layer_deps_exclude_work_dir_nested_under_layer(self):
         """Verifies Yocto build dir nested under a layer is not tracked."""
@@ -155,24 +203,18 @@ components:
             layer_dir = "test/yocto/meta-product"
             build_dir = os.path.join(layer_dir, "yocto/build/secure-image")
 
-            os.makedirs(os.path.join(layer_dir, "conf"))
-            os.makedirs(os.path.join(layer_dir, "recipes-core/images"))
+            _write_yocto_layer(layer_dir)
             os.makedirs(os.path.join(build_dir, "buildhistory/packages/acl"))
             os.makedirs(os.path.join(build_dir, "tmp/work"))
-            with open(os.path.join(layer_dir, "conf/layer.conf"), "w",
-                      encoding="utf-8") as stream:
-                stream.write("# layer configuration\n")
-            with open(os.path.join(layer_dir, "recipes-core/images/image.bb"), "w",
-                      encoding="utf-8") as stream:
-                stream.write("DESCRIPTION = \"test image\"\n")
             with open(os.path.join(build_dir, "buildhistory/packages/acl/latest"), "w",
                       encoding="utf-8") as stream:
                 stream.write("generated buildhistory\n")
             with open(os.path.join(build_dir, "tmp/work/generated.bb"), "w",
                       encoding="utf-8") as stream:
                 stream.write("generated recipe\n")
+            return [os.path.abspath(build_dir)]
 
-        depfile = self._generate_depfile(doc, setup=setup)
+        depfile = self._generate_yocto_depfile(doc, setup=setup)
 
         self.assertIn("test/yocto/meta-product/yocto/build/secure-image/target-image:",
                       depfile)
@@ -202,20 +244,153 @@ components:
         """
 
         def setup():
-            os.makedirs("test/build/generated-layer/conf")
-            os.makedirs("test/build/generated-layer/recipes-core/images")
-            with open("test/build/generated-layer/conf/layer.conf", "w",
-                      encoding="utf-8") as stream:
-                stream.write("# generated layer configuration\n")
-            with open("test/build/generated-layer/recipes-core/images/image.bb", "w",
-                      encoding="utf-8") as stream:
-                stream.write("DESCRIPTION = \"generated layer image\"\n")
+            _write_yocto_layer("test/build/generated-layer")
 
-        depfile = self._generate_depfile(doc, setup=setup)
+        depfile = self._generate_yocto_depfile(doc, setup=setup)
 
         self.assertIn("test/build/target-image:", depfile)
         self.assertIn("test/build/generated-layer/conf/layer.conf", depfile)
         self.assertIn("test/build/generated-layer/recipes-core/images/image.bb", depfile)
+
+    def test_yocto_layer_deps_exclude_bitbake_generated_dirs(self):
+        """Verifies BitBake-reported generated dirs are not tracked."""
+        doc = """
+desc: "Test build dependencies"
+components:
+  test:
+    sources:
+      - type: "null"
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      work_dir: yocto/meta-product/yocto/build/secure-image
+      conf:
+      target_images:
+        - "target-image"
+      layers:
+        - "../../.."
+        """
+
+        def setup():
+            layer_dir = "test/yocto/meta-product"
+            secure_image = os.path.join(layer_dir, "yocto/build/secure-image")
+            common_data = os.path.join(layer_dir, "yocto/build/common_data")
+
+            _write_yocto_layer(layer_dir)
+            os.makedirs(os.path.join(secure_image, "tmp/work"))
+            os.makedirs(os.path.join(common_data, "downloads/git2"))
+            with open(os.path.join(secure_image, "tmp/work/generated.bb"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("generated recipe\n")
+            with open(os.path.join(common_data, "downloads/git2/mirror.tar.gz"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("generated download\n")
+
+            return [
+                os.path.abspath(secure_image),
+                os.path.abspath(common_data),
+            ]
+
+        depfile = self._generate_yocto_depfile(doc, setup=setup)
+
+        self.assertIn("test/yocto/meta-product/yocto/build/secure-image/target-image:",
+                      depfile)
+        self.assertIn("test/yocto/meta-product/conf/layer.conf", depfile)
+        self.assertIn("test/yocto/meta-product/recipes-core/images/image.bb", depfile)
+        self.assertNotIn("tmp/work/generated.bb", depfile)
+        self.assertNotIn("common_data/downloads/git2/mirror.tar.gz", depfile)
+
+    def test_yocto_layer_deps_prune_generated_dirs_through_layer_symlink(self):
+        """Verifies generated dirs are pruned when the layer path is a symlink."""
+        doc = """
+desc: "Test build dependencies"
+components:
+  test:
+    sources:
+      - type: "null"
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      work_dir: yocto/build/secure-image
+      conf:
+      target_images:
+        - "target-image"
+      layers:
+        - "../../meta-product"
+        """
+
+        def setup():
+            layer_dir = "test/meta-product"
+            build_dir = os.path.join(layer_dir, "yocto/build/secure-image")
+            symlink_path = "test/yocto/meta-product"
+
+            _write_yocto_layer(layer_dir)
+            os.makedirs(os.path.join(build_dir, "tmp/work"))
+            os.makedirs(os.path.dirname(symlink_path))
+            os.symlink("../meta-product", symlink_path)
+
+            with open(os.path.join(build_dir, "tmp/work/generated.bb"), "w",
+                      encoding="utf-8") as stream:
+                stream.write("generated recipe\n")
+            return [os.path.abspath(build_dir)]
+
+        depfile = self._generate_yocto_depfile(doc, setup=setup)
+
+        self.assertIn("test/yocto/build/secure-image/target-image:", depfile)
+        self.assertIn("test/yocto/meta-product/conf/layer.conf", depfile)
+        self.assertIn("test/yocto/meta-product/recipes-core/images/image.bb", depfile)
+        self.assertNotIn("tmp/work/generated.bb", depfile)
+
+    def test_yocto_generated_dirs_are_read_with_bitbake_getvar(self):
+        """Verifies generated dirs are read with bitbake-getvar."""
+        run_results = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout=value)
+            for value in [
+                "/work/yocto/build/secure-image\n",
+                "/work/yocto/build/secure-image/tmp\n",
+                "/work/yocto/build/common_data/downloads\n",
+                "/work/yocto/build/common_data/sstate-cache\n",
+                "relative/path\n",
+                "\n",
+                "\n",
+                "\n",
+                "\n",
+                "\n",
+            ]
+        ]
+
+        with patch("moulin.builders.yocto._run_bash", side_effect=run_results) as run_bash:
+            paths = _get_yocto_generated_dirs("/work", "poky", "yocto/build/secure-image")
+
+        self.assertEqual(paths, [
+            "/work/yocto/build/common_data/downloads",
+            "/work/yocto/build/common_data/sstate-cache",
+            "/work/yocto/build/secure-image",
+            "/work/yocto/build/secure-image/tmp",
+        ])
+        self.assertEqual(run_bash.call_count, 10)
+        self.assertIn("oe-init-build-env yocto/build/secure-image >/dev/null",
+                      run_bash.call_args_list[0].args[0])
+        self.assertIn("bitbake-getvar --ignore-undefined --value TOPDIR",
+                      run_bash.call_args_list[0].args[0])
+
+    def test_yocto_generated_dir_query_failure_warns_and_continues(self):
+        """Verifies missing BitBake variables do not abort dep generation."""
+        values = [
+            subprocess.CalledProcessError(1, "bitbake-getvar", stderr="missing"),
+            subprocess.CompletedProcess(args=[], returncode=0,
+                                        stdout="/work/yocto/build/secure-image/tmp\n"),
+        ]
+        values.extend(subprocess.CompletedProcess(args=[], returncode=0, stdout="\n")
+                      for _ in range(8))
+
+        with patch("moulin.builders.yocto._run_bash", side_effect=values), \
+                self.assertLogs("moulin.builders.yocto", level="WARNING") as logs:
+            paths = _get_yocto_generated_dirs("/work", "poky", "yocto/build/secure-image")
+
+        self.assertEqual(paths, ["/work/yocto/build/secure-image/tmp"])
+        self.assertIn("Can't query BitBake generated directory variable TOPDIR",
+                      logs.output[0])
 
     def test_build_files_dependency_policy_rejects_unsupported_builder(self):
         """Verifies direct --dep rejects unsupported 'build_files' deps policy."""


### PR DESCRIPTION
Product layers can contain generated build trees. They can also be reached through symlinked layer paths. This can create huge depfiles and make Ninja fail.

Query BitBake generated directory variables with bitbake-getvar. Prune matching trees before os.walk descends into them, and skip layer-local .git directories so repository metadata is not recorded in depfiles.

Missing variables stay warning-only for BitBake compatibility.