### PR TITLE
Yocto populate sdk

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021-2024, EPAM Systems'
 author = 'EPAM Systems'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.31'
+release = 'v0.32'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -494,6 +494,7 @@ configuration with the layer list defined in the YAML file, and
     base_distro: poky # Optional
     work_dir: "build" # Optional
     build_target: core-image-minimal # Mandatory
+    populate_sdk: false # Optional
     conf:             # Mandatory
       - [MACHINE, "machine-name"]
       - [DISTRO_FEATURES_remove, "feature_to_remove"]
@@ -552,6 +553,12 @@ needed if you are building multiple VMs with cross-dependencies.
   "build". This is where files like "conf/local.conf" are stored. You
   can overwrite so you can produce multiple builds from the same (or
   different) set of Yocto layers.
+
+* :code:`populate_sdk` - boolean flag that also runs BitBake's SDK
+  population task. When this option is set to :code:`true`, Moulin first
+  invokes BitBake for :code:`{build_target}` to produce the configured
+  :code:`target_images`, and then invokes BitBake for the same target with
+  :code:`-c populate_sdk`.
 
 * :code:`additional_deps` - list of additional dependencies. This is
   basically :code:`target_images` produced by other components. You

--- a/moulin/builders/yocto.py
+++ b/moulin/builders/yocto.py
@@ -97,6 +97,20 @@ def gen_build_rules(generator: ninja_syntax.Writer):
                    deps="gcc",
                    depfile=".moulin_$name.d",
                    restat=True)
+    generator.newline()
+
+    cmd = " && ".join([
+        "pushd $yocto_dir > /dev/null",
+        "source $distro_dir/oe-init-build-env $work_dir",
+        "bitbake -c populate_sdk $target",
+        "popd > /dev/null",
+        "touch $out",
+    ])
+    generator.rule("yocto_populate_sdk",
+                   command=f'bash -c "{cmd}"',
+                   description="Yocto Populate SDK: $name",
+                   pool="console",
+                   restat=True)
 
 
 def _flatten_yocto_conf(conf: YamlValue) -> List[Tuple[str, str]]:
@@ -297,10 +311,21 @@ class YoctoBuilder:
                              "yocto_build",
                              local_conf_target,
                              variables=dict(common_variables,
-                                            target=self.conf["build_target"].as_str,
+                                            target=shlex.quote(self.conf["build_target"].as_str),
                                             name=self.name))
 
-        return targets
+        if not self.conf.get("populate_sdk", False).as_bool:
+            return targets
+
+        sdk_stamp = create_stamp_name(self.yocto_dir, self.work_dir, self.name, "populate_sdk")
+        self.generator.build(sdk_stamp,
+                             "yocto_populate_sdk",
+                             targets,
+                             variables=dict(common_variables,
+                                            target=shlex.quote(self.conf["build_target"].as_str),
+                                            name=self.name))
+
+        return targets + [sdk_stamp]
 
     def get_extra_dep_file_list(self) -> List[str]:
         "Return files from Moulin-managed Yocto layers."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 SETUP_ARGS: Dict[str, Any] = dict(
     name='moulin',  # Required
-    version='0.31',  # Required
+    version='0.32',  # Required
     description='Meta-build system',  # Required
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/unittest/test_yocto_builder.py
+++ b/tests/unittest/test_yocto_builder.py
@@ -99,6 +99,51 @@ components:
         else:
             self.fail("Could not find yocto_build target")
 
+    def test_populate_sdk(self):
+        doc = """
+desc: "Test build"
+components:
+  test:
+    builder:
+      type: "yocto"
+      build_target: core-image-minimal
+      populate_sdk: true
+      conf:
+      target_images:
+        - "target-image"
+    sources:
+      - type: "null"
+        """
+        node = yaml.compose(doc)
+        conf = MoulinConfiguration(node)
+        generate_build(conf, "test.yaml")
+
+        image_targets = ["test/build/target-image"]
+        sdk_stamp = None
+        found_image_build = False
+        found_sdk_build = False
+        for call in self.Writer.return_value.build.call_args_list:
+            if call.args[1] == "yocto_build":
+                self.assertListEqual(call.args[0], image_targets)
+                self.assertIn("variables", call.kwargs)
+                self.assertIn("target", call.kwargs["variables"])
+                self.assertEqual(call.kwargs["variables"]["target"], "core-image-minimal")
+                found_image_build = True
+            elif call.args[1] == "yocto_populate_sdk":
+                sdk_stamp = call.args[0]
+                self.assertListEqual(call.args[2], image_targets)
+                self.assertIn("variables", call.kwargs)
+                self.assertIn("target", call.kwargs["variables"])
+                self.assertEqual(call.kwargs["variables"]["target"], "core-image-minimal")
+                found_sdk_build = True
+
+        self.assertTrue(found_image_build, "Could not find yocto_build target")
+        self.assertTrue(found_sdk_build, "Could not find yocto_populate_sdk target")
+        self.Writer.return_value.build.assert_any_call(
+            "test",
+            "phony",
+            image_targets + [sdk_stamp])
+
     def test_layer_sync_passes_distro_dir(self):
         doc = """
 desc: "Test build"


### PR DESCRIPTION
yocto: add populate_sdk builder option

Allow Yocto components to request BitBake SDK generation by setting
populate_sdk to true. The default build path still invokes the
configured build_target directly.

When populate_sdk is enabled, pass -c populate_sdk together with the
build target through the generated Ninja rule. Keep target_images as the
declared outputs so callers can point Moulin at the expected SDK
installer path.

Document the new option and cover the generated bitbake arguments in the
Yocto builder unit tests.

----

version: bump version to 0.32

Taking into account added Yocto populate_sdk builder option and other
changes, bump the version up.